### PR TITLE
Add n species to hovering

### DIFF
--- a/R/visualize_species_per_deployment.R
+++ b/R/visualize_species_per_deployment.R
@@ -10,8 +10,12 @@
 #' @param cluster a logical value indicating whether using the cluster option
 #'   while visualizing maps. Default: TRUE
 #' @param hover_column character with the name of the column to use for showing
-#'   location deployment information while hovering the mouse over. By default:
-#'   `deployment_id`. Use `NULL` to disable hovering.
+#'   location deployment information while hovering the mouse over. One from:
+#'   - `n`: number of species (default)
+#'   - `deployment_id`
+#'   - `location_id`
+#'   - `location_name`
+#'   - `NULL`: hovering disabled
 #'
 #' @importFrom dplyr .data count distinct group_by left_join mutate one_of
 #'   select %>%
@@ -39,7 +43,7 @@
 visualize_species_per_deployment <- function(deployments,
                                              observations,
                                              cluster = TRUE,
-                                             hover_column = "deployment_id") {
+                                             hover_column = "n") {
 
   # get species detected by each deployment
   species <-

--- a/man/visualize_species_per_deployment.Rd
+++ b/man/visualize_species_per_deployment.Rd
@@ -8,7 +8,7 @@ visualize_species_per_deployment(
   deployments,
   observations,
   cluster = TRUE,
-  hover_column = "deployment_id"
+  hover_column = "n"
 )
 }
 \arguments{
@@ -20,8 +20,14 @@ visualize_species_per_deployment(
 while visualizing maps. Default: TRUE}
 
 \item{hover_column}{character with the name of the column to use for showing
-location deployment information while hovering the mouse over. By default:
-\code{deployment_id}. Use \code{NULL} to disable hovering.}
+location deployment information while hovering the mouse over. One from:
+\itemize{
+\item \code{n}: number of species (default)
+\item \code{deployment_id}
+\item \code{location_id}
+\item \code{location_name}
+\item \code{NULL}: hovering disabled
+}}
 }
 \value{
 a leaflet map

--- a/vignettes/visualize-number-of-species-per-deployment.Rmd
+++ b/vignettes/visualize-number-of-species-per-deployment.Rmd
@@ -30,7 +30,12 @@ This load automatically a camera trap data package, `camtrapdp`, containing came
 
 ## Create map
 
-You can visualize the number of species detected by each deployment by using the function `visualize_species_per_deployment()`. You can benefit of the `cluster` mode, which is set to `TRUE` by default. You can also specify the column you want to show while hovering with the mouse over the deployment. By default the  `deployment_id` is used.
+You can visualize the number of species detected by each deployment by using the function `visualize_species_per_deployment()`. You can benefit of the `cluster` mode, which is set to `TRUE` by default. You can also specify which information you want to show while hovering with the mouse over the deployment. By default the number of species (`n`) is shown. Other possible values are:
+
+- `deployment_id`
+- `location_id`
+- `location_name`
+- `NULL` to disable hovering
 
 ```{r visualize_with_clusters_and_default_hover_col}
 visualize_species_per_deployment(deployments = camtrapdp$deployments,
@@ -45,10 +50,11 @@ visualize_species_per_deployment(deployments = camtrapdp$deployments,
                                  hover_column = "location_name")
 ```
 
-Deactivating the cluster mode:
+Deactivating both cluster mode and hovering:
 
 ```{r visualize_without_clusters}
 visualize_species_per_deployment(deployments = camtrapdp$deployments,
                                  observations = camtrapdp$observations,
-                                 cluster = FALSE)
+                                 cluster = FALSE,
+                                 hover_column = NULL)
 ```


### PR DESCRIPTION
This PR should solve #5 by providing number of species as default option for arg `hover_column`.
Function, documentation and vignette updated.