### PR TITLE
Add time unit get effort

### DIFF
--- a/R/get_effort.R
+++ b/R/get_effort.R
@@ -34,7 +34,7 @@
 #' get_effort(camtrapdp)
 #'
 #' # effort expressed as days
-#' get_effort(camtrapdp, effort_unit = "day")
+#' get_effort(camtrapdp, unit = "day")
 #'
 get_effort <- function(datapkg, unit = NULL) {
 

--- a/R/get_effort.R
+++ b/R/get_effort.R
@@ -38,6 +38,17 @@
 #'
 get_effort <- function(datapkg, unit = NULL) {
 
+  # define possible unit values
+  units <- c("second",
+             "minute",
+             "hour",
+             "day",
+             "month",
+             "year")
+
+  # check unit
+  check_value(unit, units, "unit", null_allowed = TRUE)
+
   # get deployments
   deployments <- datapkg$deployments
 

--- a/R/get_effort.R
+++ b/R/get_effort.R
@@ -10,8 +10,18 @@
 #' 3. `multimedia`
 #'
 #' and a list with metadata: `datapackage`
+#' @param unit time unit to use while returning deployment effort
+#'   (duration). One of:
 #'
-#' @importFrom dplyr .data %>% mutate %>% select
+#' - `second`
+#' - `minute`
+#' - `hour`
+#' - `day`
+#' - `month`
+#' - `year`
+#' - `NULL` (default) duration objects (e.g. 2594308s (~4.29 weeks))
+#'
+#' @importFrom dplyr .data %>% mutate %>% select mutate
 #' @importFrom lubridate as.duration
 #' @export
 
@@ -20,17 +30,32 @@
 #' - `effort`: a duration object (duration is a class from lubridate package)
 #'
 #' @examples
+#' # efforts expressed as Durations
 #' get_effort(camtrapdp)
 #'
-get_effort <- function(datapkg) {
+#' # effort expressed as days
+#' get_effort(camtrapdp, effort_unit = "day")
+#'
+get_effort <- function(datapkg, unit = NULL) {
 
   # get deployments
   deployments <- datapkg$deployments
 
   # calculate effort of deployments
-  deployments %>%
+  effort_df <-
+    deployments %>%
     mutate(effort = as.duration(.data$end - .data$start)) %>%
     select(.data$deployment_id, .data$effort)
+  # convert effort in specified effort time units (arg units)
+  if (!is.null(unit)) {
+    effort_df$effort <- transform_effort_to_common_units(
+      effort = effort_df$effort,
+      unit = unit)
+    effort_df$effort_unit <- unit
+  } else {
+    effort_df$effort_unit <- "Duration"
+  }
+  return(effort_df)
 }
 
 #' Transform efforts to common units.
@@ -73,11 +98,11 @@ transform_effort_to_common_units <- function(effort, unit) {
   assert_that(length(unit) == 1,
               msg = "unit must have length 1")
 
-  # define possible unit values
-  units <- c("second", "minute", "hour", "day", "week", "month", "year")
+  # define possible effort_unit values
+  effort_units <- c("second", "minute", "hour", "day", "week", "month", "year")
 
   # check effort_unit
-  check_value(unit, units, "unit", null_allowed = FALSE)
+  check_value(unit, effort_units, "effort_unit", null_allowed = FALSE)
 
   if (unit == "second") {
     effort / dseconds()

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -181,19 +181,11 @@ map_dep <- function(datapkg,
   assert_that(length(feature) == 1,
               msg = "feature must have length 1")
 
-  # define possible effort_unit values
-  effort_units <- c("second", "minute", "hour", "day", "week", "month", "year")
-
   # check effort_unit in combination with feature
   if (!is.null(effort_unit) & feature != "effort") {
     warning(glue("effort_unit argument ignored for feature = {feature}"))
     effort_unit <- NULL
   }
-
-  # check effort_unit
-  check_value(effort_unit, effort_units, "effort_unit", null_allowed = TRUE)
-  assert_that(length(effort_unit) <= 1,
-              msg = "effort_unit must have length 1 or be NULL")
 
   # extract observations and deployments
   observations <- datapkg$observations
@@ -260,11 +252,7 @@ map_dep <- function(datapkg,
     feat_df <- get_rai(datapkg, species = species)
     feat_df <- feat_df %>% rename(n = .data$rai)
   } else if (feature == "effort") {
-    feat_df <- get_effort(datapkg)
-    if (!is.null(effort_unit)) {
-      feat_df$effort <- transform_effort_to_common_units(feat_df$effort,
-                                                         unit = effort_unit)
-    }
+    feat_df <- get_effort(datapkg, unit = effort_unit)
     feat_df <- feat_df %>% rename(n = .data$effort)
   }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -42,10 +42,12 @@ check_datapkg <- function(datapkg) {
 #' provided values. NULL values can be allowed (default) or not by setting
 #' argument `null_allowed` equal to `TRUE` or `FALSE`.
 #'
-#' @param arg Character. The input argument provided by the user.
-#' @param options Character vector of valid inputs for the argument.
-#' @param arg_name Character. The name of the argument used in the function to
-#'   test.
+#' @param arg character containing the input argument provided by the user
+#' @param options haracter vector of valid inputs for the argument
+#' @param arg_name character with the name of the argument used in the function
+#'   to test
+#' @param null_allowed logical (`TRUE`, the default, or `FALSE`) Are NULL values
+#'   allowed?
 #'
 #' @return If no error, `TRUE`.
 #'
@@ -80,9 +82,16 @@ check_value <- function(arg, options = NULL, arg_name, null_allowed = TRUE) {
   }
 
   # compose error message
+  if (null_allowed == TRUE) {
+    string_to_print <- "Invalid value for {arg_name} argument.
+        Valid inputs are: NULL, {options_to_print*}."
+  } else {
+    string_to_print <- "Invalid value for {arg_name} argument.
+        Valid inputs are: {options_to_print*}."
+  }
+
   msg_to_print <- glue(
-    "Invalid value for {arg_name} argument.
-        Valid inputs are: {options_to_print*}.",
+    string_to_print,
     .transformer = collapse_transformer(
       sep = ", ",
       last = " and "

--- a/man/get_effort.Rd
+++ b/man/get_effort.Rd
@@ -44,6 +44,6 @@ Function to get the effort (deployment duration) per deployment.
 get_effort(camtrapdp)
 
 # effort expressed as days
-get_effort(camtrapdp, effort_unit = "day")
+get_effort(camtrapdp, unit = "day")
 
 }

--- a/man/get_effort.Rd
+++ b/man/get_effort.Rd
@@ -4,7 +4,7 @@
 \alias{get_effort}
 \title{Get effort}
 \usage{
-get_effort(datapkg)
+get_effort(datapkg, unit = NULL)
 }
 \arguments{
 \item{datapkg}{a camera trap data package object, as returned by
@@ -16,6 +16,18 @@ get_effort(datapkg)
 }
 
 and a list with metadata: \code{datapackage}}
+
+\item{unit}{time unit to use while returning deployment effort
+(duration). One of:
+\itemize{
+\item \code{second}
+\item \code{minute}
+\item \code{hour}
+\item \code{day}
+\item \code{month}
+\item \code{year}
+\item \code{NULL} (default) duration objects (e.g. 2594308s (~4.29 weeks))
+}}
 }
 \value{
 a tibble (data.frame) with the following columns:
@@ -28,6 +40,10 @@ a tibble (data.frame) with the following columns:
 Function to get the effort (deployment duration) per deployment.
 }
 \examples{
+# efforts expressed as Durations
 get_effort(camtrapdp)
+
+# effort expressed as days
+get_effort(camtrapdp, effort_unit = "day")
 
 }

--- a/tests/testthat/test-get_effort.R
+++ b/tests/testthat/test-get_effort.R
@@ -1,0 +1,64 @@
+test_that("get_effort returns error if species is specified", {
+
+  expect_error(get_effort(camtrapdp, species = "Mallard"))
+  expect_error(get_effort(camtrapdp, species = character(0)))
+})
+
+test_that("get_effort returns error for invalid effort units", {
+  expect_error(get_effort(camtrapdp, unit = "bad_unit"))
+})
+
+test_that("values in column effort_unit are all the same", {
+  effort_df <- get_effort(camtrapdp)
+  distinct_efffort_unit_values <- unique(effort_df$effort_unit)
+  expect_equal(length(distinct_efffort_unit_values), 1)
+})
+
+test_that("column effort_unit is equal to 'Duration' if unit is NULL", {
+  effort_df <- get_effort(camtrapdp)
+  efffort_unit_value <- unique(effort_df$effort_unit)
+  expect_equal(efffort_unit_value, "Duration")
+})
+
+test_that("column effort_unit is always equal to unit if unit is not NULL", {
+  unit_to_test<- c("second", "minute", "hour", "day", "month", "year")
+  for (chosen_unit in unit_to_test) {
+    effort_df <- get_effort(camtrapdp, unit = chosen_unit)
+    efffort_unit_value <- unique(effort_df$effort_unit)
+    expect_equal(efffort_unit_value, chosen_unit)
+  }
+})
+
+
+test_that("get_effort returns the right dataframe", {
+
+  effort_df <- get_effort(camtrapdp)
+
+  # type list
+  expect_type(effort_df, "list")
+
+  # class tibble data.frame
+  expect_equal(class(effort_df),
+               c("tbl_df", "tbl", "data.frame"))
+
+  # columns deployment_id effort and effort_unit only
+  expect_equal(names(effort_df),
+               c("deployment_id",
+                 "effort",
+                 "effort_unit"))
+})
+
+
+test_that("get_effort returns the right number of rows", {
+
+  effort_df <- get_effort(camtrapdp)
+  all_deployments <- unique(camtrapdp$deployments$deployment_id)
+  n_all_deployments <- length(all_deployments)
+
+  # number of rows should be equal to number of deployments
+  expect_equal(nrow(effort_df),
+               n_all_deployments)
+
+})
+
+

--- a/vignettes/visualize-deployment-features.Rmd
+++ b/vignettes/visualize-deployment-features.Rmd
@@ -105,7 +105,7 @@ testthat::expect_error(
           feature = "rai",
           species = "This is not a species name"), 
   paste0("Invalid value for species argument.\n",
-         "Valid inputs are: anas platyrhynchos, rattus norvegicus, ",
+         "Valid inputs are: NULL, anas platyrhynchos, rattus norvegicus, ",
          "ondatra zibethicus, myocastor coypus, gallinula chloropus, ", 
          "mallard, norway rat, muskrat, coypu and common moorhen.")
 )


### PR DESCRIPTION
This PR solves #24 

Also it does:
1. add unit-tests for `get_effort()`
2. improve informative message when wrong `effort_unit` value is passed to the function, by adding `NULL` to the list of possible values, e.g.
```r
> get_effort(camtrapdp, unit = "bad")
 Error: Invalid value for unit argument.
Valid inputs are: NULL, second, minute, hour, day, month and year. 
```

This small improvement applies to other functions where NULL is a possible value of an argument, e.g. `species` argument of `get_n_obs()` function:
```r
> get_n_obs(camtrapdp, species = "bad!")
 Error: Invalid value for species argument.
Valid inputs are: NULL, anas platyrhynchos, rattus norvegicus, ondatra zibethicus, myocastor coypus, gallinula chloropus, mallard, norway rat, muskrat, coypu and common moorhen. 
```