### PR TITLE
Improve input checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtrapdp
 Title: Visualize camtrap-dp formatted data
-Version: 0.1.0.9007
+Version: 0.1.0.9008
 Authors@R: c(
     person(given = "Damiano",
            family = "Oldoni",

--- a/R/filter_predicates.R
+++ b/R/filter_predicates.R
@@ -319,6 +319,7 @@ pred_or <- function(...) {
 #' @param ... filter predicates to apply to `df`
 #'
 #' @importFrom glue glue
+#' @importFrom assertthat assert_that
 #'
 #' @return a data.frame
 #' @export
@@ -342,6 +343,7 @@ pred_or <- function(...) {
 #'                        pred_or(pred_gte("latitude", 51.28),
 #'                                 pred_lt("longitude", 3.56)))
 apply_filter_predicate <- function(df, verbose, ...) {
+  assert_that(is.data.frame(df), msg = "Predicates must be applied to a df")
   preds <- list(...)
   if (length(preds) > 0) {
     filters <- pred_and(...)

--- a/R/get_effort.R
+++ b/R/get_effort.R
@@ -49,6 +49,8 @@ get_effort <- function(datapkg, ..., unit = NULL) {
   # check unit
   check_value(unit, units, "unit", null_allowed = TRUE)
 
+  # check datapackage
+  check_datapkg(datapkg)
   # get deployments
   deployments <- datapkg$deployments
 

--- a/tests/testthat/test-filter_predicates.R
+++ b/tests/testthat/test-filter_predicates.R
@@ -274,6 +274,8 @@ test_that("specific tests: nesting pred_and and pred_or", {
 })
 
 test_that("apply_filter_predicate returns error if input is not a df", {
-  expect_error(apply_filter_predicate("a", pred(arg = "col1", value = "b")),
-               "Predicates must be applied to a df")
+  expect_error(
+    apply_filter_predicate("a", pred(arg = "col1", value = "b")),
+    "Predicates must be applied to a df"
+  )
 })

--- a/tests/testthat/test-filter_predicates.R
+++ b/tests/testthat/test-filter_predicates.R
@@ -272,3 +272,8 @@ test_that("specific tests: nesting pred_and and pred_or", {
     )
   )
 })
+
+test_that("apply_filter_predicate returns error if input is not a df", {
+  expect_error(apply_filter_predicate("a", pred(arg = "col1", value = "b")),
+               "Predicates must be applied to a df")
+})

--- a/tests/testthat/test-get_effort.R
+++ b/tests/testthat/test-get_effort.R
@@ -7,6 +7,11 @@ test_that("get_effort returns error for invalid effort units", {
   expect_error(get_effort(camtrapdp, unit = "bad_unit"))
 })
 
+test_that("get_effort returns error for invalid datapackage", {
+  expect_error(get_effort(camtrapdp$deployments))
+})
+
+
 test_that("values in column effort_unit are all the same", {
   effort_df <- get_effort(camtrapdp)
   distinct_efffort_unit_values <- unique(effort_df$effort_unit)


### PR DESCRIPTION
Apply defensive programming strategy even in `get_effort()` and `apply_filter_predicate()` functions by better checking the input of these two functions.