### PR TITLE
Switch resourcename package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtrapdp
 Title: Visualize camtrap-dp formatted data
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person(given = "Damiano",
            family = "Oldoni",

--- a/R/read_camtrap_dp.R
+++ b/R/read_camtrap_dp.R
@@ -43,8 +43,8 @@ read_camtrap_dp <- function(path, media = TRUE) {
               msg = "media must be a logical: TRUE or FALSE")
   # read files
   package <- read_package(file.path(path, "datapackage.json"))
-  deployments <- read_resource(package, "deployments")
-  observations <- read_resource(package, "observations")
+  deployments <- read_resource("deployments", package)
+  observations <- read_resource("observations", package)
 
   taxon_infos <- get_species(list(
     "datapackage" = package,
@@ -62,7 +62,7 @@ read_camtrap_dp <- function(path, media = TRUE) {
       relocate(one_of(cols_taxon_infos), .after = .data$cameraSetup)
   }
   if (media == TRUE) {
-    media <- read_resource(package, "media")
+    media <- read_resource("media", package)
   }
 
   # return list

--- a/tests/testthat/test-read_camtrap_dp.R
+++ b/tests/testthat/test-read_camtrap_dp.R
@@ -11,12 +11,20 @@ test_that("media is checked properly", {
   )
 })
 
+test_that("output is a list", {
+  dp_path <- system.file("extdata", "mica", package = "camtrapdp")
+  dp_without_media <- read_camtrap_dp(
+    path = dp_path,
+    media = FALSE)
+  expect_true(is.list(dp_without_media))
+  expect_equal(class(dp_without_media), "list")
+})
+
 test_that("output is a list of length 4", {
   dp_path <- system.file("extdata", "mica", package = "camtrapdp")
   dp_without_media <- read_camtrap_dp(
     path = dp_path,
     media = FALSE)
-  expect_equal(class(dp_without_media), "list")
   expect_equal(length(dp_without_media), 4)
 })
 
@@ -55,7 +63,7 @@ test_that("Datapackage metadata is a list", {
   dp_without_media <- read_camtrap_dp(
     path = dp_path,
     media = FALSE)
- expect_equal(class(dp_without_media$datapackage), "list")
+ expect_equal(class(dp_without_media$datapackage), c("datapackage", "list"))
 })
 
 test_that("Datapackage resources are named as in metadata$resource_names", {

--- a/tests/testthat/test-read_camtrap_dp.R
+++ b/tests/testthat/test-read_camtrap_dp.R
@@ -63,7 +63,7 @@ test_that("Datapackage metadata is a list", {
   dp_without_media <- read_camtrap_dp(
     path = dp_path,
     media = FALSE)
- expect_equal(class(dp_without_media$datapackage), c("datapackage", "list"))
+  expect_s3_class(dp_without_media$datapackage, "datapackage")
 })
 
 test_that("Datapackage resources are named as in metadata$resource_names", {


### PR DESCRIPTION
Small PR to follow switch of args in `datapackage::read_resource()`, see https://github.com/inbo/datapackage/pull/36