### PR TITLE
Switch back resource name and package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtrapdp
 Title: Visualize camtrap-dp formatted data
-Version: 0.4.1
+Version: 0.4.2
 Authors@R: c(
     person(given = "Damiano",
            family = "Oldoni",

--- a/R/read_camtrap_dp.R
+++ b/R/read_camtrap_dp.R
@@ -43,8 +43,8 @@ read_camtrap_dp <- function(path, media = TRUE) {
               msg = "media must be a logical: TRUE or FALSE")
   # read files
   package <- read_package(file.path(path, "datapackage.json"))
-  deployments <- read_resource("deployments", package)
-  observations <- read_resource("observations", package)
+  deployments <- read_resource(package, "deployments")
+  observations <- read_resource(package, "observations")
 
   taxon_infos <- get_species(list(
     "datapackage" = package,
@@ -62,7 +62,7 @@ read_camtrap_dp <- function(path, media = TRUE) {
       relocate(one_of(cols_taxon_infos), .after = .data$cameraSetup)
   }
   if (media == TRUE) {
-    media <- read_resource("media", package)
+    media <- read_resource(package, "media")
   }
 
   # return list


### PR DESCRIPTION
This reverts https://github.com/inbo/camtrapdp/commit/33ec61043f0aaff7099bf1ff7bc53b0a8b4600dd to reflect the change in `frictionless` package (see https://github.com/frictionlessdata/frictionless-r/issues/53).