### PR TITLE
Color palette for map_dep()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ Imports:
     dplyr,
     frictionless,
     glue,
-    grDevices,
     here,
     htmltools,
     leaflet,

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -442,17 +442,10 @@ map_dep <- function(datapkg,
   )
 
   # define color palette
-  palette_colors <- c("white", "blue")
+  # palette_colors <- c("white", "blue")
   pal <- leaflet::colorNumeric(
-    palette = palette_colors,
+    palette = "magma",
     domain = c(0, max_n)
-  )
-  # remove NA color to legend until this issue is solved:
-  # https://github.com/rstudio/leaflet/issues/615
-  pal_without_na <- leaflet::colorNumeric(
-    palette = palette_colors,
-    domain = c(0, max_n),
-    na.color = grDevices::rgb(0, 0, 0, 0)
   )
 
   # define bins for ticks of legend
@@ -483,12 +476,12 @@ map_dep <- function(datapkg,
       radius = ~ ifelse(is.na(n), radius_min, n * conv_factor + radius_min),
       color = ~ pal(n),
       stroke = FALSE,
-      fillOpacity = 0.5,
-      label = ~hover_info,
+      fillOpacity = 0.8,
+      label = ~ hover_info,
       clusterOptions = if (cluster == TRUE) leaflet::markerClusterOptions() else NULL
     ) %>%
     leaflet::addLegend("bottomright",
-              pal = pal_without_na,
+              pal = pal,
               values = legend_values,
               title = title,
               opacity = 1,

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -206,7 +206,14 @@
 #'   palette = "BuPu"
 #' )
 #'
-#' # use a palette defined by hex colors
+#' # use a palette defined by color names
+#' map_dep(
+#'   mica,
+#'   "n_obs",
+#'   palette = palette(c("black", "blue", "white"))
+#' )
+#'
+#' #' # use a palette defined by hex colors
 #' map_dep(
 #'   mica,
 #'   "n_obs",
@@ -293,6 +300,29 @@ map_dep <- function(datapkg,
                                       "rai_individuals")) {
     warning(glue::glue("life_stage argument ignored for feature = {feature}"))
     life_stage <- NULL
+  }
+
+  # check palette
+  viridis_valid_palettes <- c(
+    "magma",
+    "inferno",
+    "plasma",
+    "viridis"
+  )
+  r_color_brewer_palettes <- rownames(RColorBrewer::brewer.pal.info)
+  palettes <- c(viridis_valid_palettes, r_color_brewer_palettes)
+  assertthat::assert_that(
+    length(palette) > 0,
+    msg = "Argument palette must be a valid color palette."
+  )
+  if (length(palette) == 1) {
+    check_value(arg = palette,
+                options = palettes,
+                arg_name = "palette",
+                null_allowed = FALSE
+    )
+  } else {
+
   }
 
   # extract observations and deployments

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -5,19 +5,19 @@
 #' color are proportional to the mapped feature. Deployments without
 #' observations are shown as gray circles and a message is returned.
 #'
-#' @param datapkg a camera trap data package object, as returned by
+#' @param datapkg Camera trap data package object, as returned by
 #'   `read_camtrap_dp()`.
-#' @param feature character, deployment feature to visualize. One of:
+#' @param feature deployment feature to visualize. One of:
 #'
-#' - `n_species`: number of identified species
-#' - `n_obs`: number of observations
-#' -  `n_individuals`: number of individuals
-#' - `rai`: Relative Abundance Index
-#' - `effort`: effort (duration) of the deployment
+#' - `"n_species"`: number of identified species
+#' - `"n_obs"`: number of observations
+#' -  `"n_individuals"`: number of individuals
+#' - `"rai"`: Relative Abundance Index
+#' - `"effort"`: effort (duration) of the deployment
 #'
-#' @param species a character with a scientific name. Required for  `rai`,
-#'   optional for `n_obs`. Default: `NULL`
-#' @param effort_unit time unit to use while visualizing deployment effort
+#' @param species Character with a scientific name. Required for  `rai`,
+#'   optional for `n_obs`. Default: `NULL`.
+#' @param effort_unit Time unit to use while visualizing deployment effort
 #'   (duration). One of:
 #'
 #' - `second`
@@ -27,18 +27,17 @@
 #' - `month`
 #' - `year`
 #' - `NULL` (default) duration objects (e.g. 2594308s (~4.29 weeks)) are shown
-#' while hovering and seconds shown in legend
-#' @param sex a character defining the sex class to filter on, e.g. `"female"`.
+#' while hovering and seconds shown in legend.
+#' @param sex Character defining the sex class to filter on, e.g. `"female"`.
 #'   If `NULL`, default, all observations of all sex classes are taken into
-#'   account. Optional argument for `n_obs` and `n_individuals`
-#' @param life_stage a character vector defining the life stage class to filter on, e.g.
+#'   account. Optional argument for `n_obs` and `n_individuals`.
+#' @param life_stage Character vector defining the life stage class to filter on, e.g.
 #'   `"adult"` or `c("subadult", "adult")`. If `NULL`, default, all observations
 #'   of all life stage classes are taken into account. Optional argument for `n_obs`
-#'   and `n_individuals`
-#' @param cluster a logical value
-#'   indicating whether using the cluster option while visualizing maps.
-#'   Default: TRUE
-#' @param hover_columns character with the name of the columns to use for
+#'   and `n_individuals`.
+#' @param cluster Logical value indicating whether using the cluster option
+#'   while visualizing maps. Default: TRUE.
+#' @param hover_columns Character vector with the name of the columns to use for
 #'   showing location deployment information while hovering the mouse over. One
 #'   or more from deployment columns. Use `NULL` to disable hovering. Default
 #'   information:
@@ -56,19 +55,19 @@
 #'
 #'   See [section Deployment of Camtrap DP
 #'   standard](https://tdwg.github.io/camtrap-dp/data/#deployments) for the full
-#'   list of columns you can use
 #' @param relative_scale a logical indicating whether to use a relative color
+#'   list of columns you can use.
 #'   and radius scale (`TRUE`) or an absolute scale (`FALSE`). If absolute scale
-#'   is used, specify a valid `max_scale`
-#' @param max_scale a number indicating the max value used to map color
-#'   and radius
-#' @param radius_range a vector of length 2 containing the lower and upper limit
+#'   is used, specify a valid `max_scale`.
+#' @param max_scale Number indicating the max value used to map color
+#'   and radius.
+#' @param radius_range Vector of length 2 containing the lower and upper limit
 #'   of the circle radius. The lower value is used for deployments with zero
 #'   feature value, i.e. no observations, no identified species, zero RAI or
 #'   zero effort. The upper value is used for the deployment(s) with the highest
 #'   feature value (`relative_scale` = `TRUE`) or `max_scale` (`relative_scale`
 #'   = `FALSE`). Default: `c(10, 50)`
-#' @param ... filter predicates for subsetting deployments
+#' @param ... Filter predicates for subsetting deployments.
 #'
 #' @seealso Check documentation about filter predicates: [pred()], [pred_in()],
 #'   [pred_and()], ...

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -55,8 +55,17 @@
 #'
 #'   See [section Deployment of Camtrap DP
 #'   standard](https://tdwg.github.io/camtrap-dp/data/#deployments) for the full
-#' @param relative_scale a logical indicating whether to use a relative color
 #'   list of columns you can use.
+#' @param palette The palette name or the color function that values will be
+#'   mapped to.
+#'   Typically one of the following:
+#'   - A character vector of RGB or named colors. Examples: `palette(),
+#'   c("#000000", "#0000FF", "#FFFFFF"), topo.colors(10)`.
+#'   - the full name of a RColorBrewer palette, e.g. "BuPu" or "Greens", or
+#'   viridis palette: `"viridis"`, `"magma"`, `"inferno"` or `"plasma"`
+#'   For more options, see argument `palette` of [leaflet::colorNumeric()].
+#'
+#' @param relative_scale Logical indicating whether to use a relative color
 #'   and radius scale (`TRUE`) or an absolute scale (`FALSE`). If absolute scale
 #'   is used, specify a valid `max_scale`.
 #' @param max_scale Number indicating the max value used to map color
@@ -183,7 +192,28 @@
 #'   effort_unit = "month"
 #' )
 #'
-#' # cluster disabled
+#' # use viridis palette
+#' map_dep(
+#'   mica,
+#'   "n_obs",
+#'   palette = "viridis"
+#' )
+#'
+#' # use a palette defined by color names
+#' map_dep(
+#'   mica,
+#'   "n_obs",
+#'   palette = palette(value = c("black", "blue", "white"))
+#' )
+#'
+#' # use a palette defined by hex colors
+#' map_dep(
+#'   mica,
+#'   "n_obs",
+#'   palette = palette(c("#000000", "#0000FF", "#FFFFFF"))
+#' )
+#'
+#' # disable cluster
 #' map_dep(mica,
 #'   "n_species",
 #'   cluster = FALSE
@@ -221,6 +251,7 @@ map_dep <- function(datapkg,
                                       "locationID", "locationName",
                                       "latitude", "longitude",
                                       "start", "end"),
+                    palette = "inferno",
                     relative_scale = TRUE,
                     max_scale = NULL,
                     radius_range = c(10, 50)
@@ -441,9 +472,8 @@ map_dep <- function(datapkg,
   )
 
   # define color palette
-  # palette_colors <- c("white", "blue")
   pal <- leaflet::colorNumeric(
-    palette = "magma",
+    palette = palette,
     domain = c(0, max_n)
   )
 

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -192,18 +192,18 @@
 #'   effort_unit = "month"
 #' )
 #'
-#' # use viridis palette
+#' # use viridis palette (viridis palettes)
 #' map_dep(
 #'   mica,
 #'   "n_obs",
 #'   palette = "viridis"
 #' )
 #'
-#' # use a palette defined by color names
+#' # use "BuPu" color palette (RColorBrewer palettes)
 #' map_dep(
 #'   mica,
 #'   "n_obs",
-#'   palette = palette(value = c("black", "blue", "white"))
+#'   palette = "BuPu"
 #' )
 #'
 #' # use a palette defined by hex colors

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -100,7 +100,7 @@
 #'   species = "Anas platyrhynchos"
 #' )
 #'
-#' # show number of observations of subadult individuals of AnasAnas strepera
+#' # show number of observations of subadult individuals of Anas strepera
 #' map_dep(
 #'   mica,
 #'   "n_obs",

--- a/man/map_dep.Rd
+++ b/man/map_dep.Rd
@@ -129,7 +129,7 @@ map_dep(
   species = "Anas platyrhynchos"
 )
 
-# show number of observations of subadult individuals of AnasAnas strepera
+# show number of observations of subadult individuals of Anas strepera
 map_dep(
   mica,
   "n_obs",

--- a/man/map_dep.Rd
+++ b/man/map_dep.Rd
@@ -15,39 +15,40 @@ map_dep(
   cluster = TRUE,
   hover_columns = c("n", "species", "deploymentID", "locationID", "locationName",
     "latitude", "longitude", "start", "end"),
+  palette = "inferno",
   relative_scale = TRUE,
   max_scale = NULL,
   radius_range = c(10, 50)
 )
 }
 \arguments{
-\item{datapkg}{a camera trap data package object, as returned by
+\item{datapkg}{Camera trap data package object, as returned by
 \code{read_camtrap_dp()}.}
 
-\item{feature}{character, deployment feature to visualize. One of:
+\item{feature}{deployment feature to visualize. One of:
 \itemize{
-\item \code{n_species}: number of identified species
-\item \code{n_obs}: number of observations
-\item \code{n_individuals}: number of individuals
-\item \code{rai}: Relative Abundance Index
-\item \code{effort}: effort (duration) of the deployment
+\item \code{"n_species"}: number of identified species
+\item \code{"n_obs"}: number of observations
+\item \code{"n_individuals"}: number of individuals
+\item \code{"rai"}: Relative Abundance Index
+\item \code{"effort"}: effort (duration) of the deployment
 }}
 
-\item{...}{filter predicates for subsetting deployments}
+\item{...}{Filter predicates for subsetting deployments.}
 
-\item{species}{a character with a scientific name. Required for  \code{rai},
-optional for \code{n_obs}. Default: \code{NULL}}
+\item{species}{Character with a scientific name. Required for  \code{rai},
+optional for \code{n_obs}. Default: \code{NULL}.}
 
-\item{sex}{a character defining the sex class to filter on, e.g. \code{"female"}.
+\item{sex}{Character defining the sex class to filter on, e.g. \code{"female"}.
 If \code{NULL}, default, all observations of all sex classes are taken into
-account. Optional argument for \code{n_obs} and \code{n_individuals}}
+account. Optional argument for \code{n_obs} and \code{n_individuals}.}
 
-\item{life_stage}{a character vector defining the life stage class to filter on, e.g.
+\item{life_stage}{Character vector defining the life stage class to filter on, e.g.
 \code{"adult"} or \code{c("subadult", "adult")}. If \code{NULL}, default, all observations
 of all life stage classes are taken into account. Optional argument for \code{n_obs}
-and \code{n_individuals}}
+and \code{n_individuals}.}
 
-\item{effort_unit}{time unit to use while visualizing deployment effort
+\item{effort_unit}{Time unit to use while visualizing deployment effort
 (duration). One of:
 \itemize{
 \item \code{second}
@@ -57,14 +58,13 @@ and \code{n_individuals}}
 \item \code{month}
 \item \code{year}
 \item \code{NULL} (default) duration objects (e.g. 2594308s (~4.29 weeks)) are shown
-while hovering and seconds shown in legend
+while hovering and seconds shown in legend.
 }}
 
-\item{cluster}{a logical value
-indicating whether using the cluster option while visualizing maps.
-Default: TRUE}
+\item{cluster}{Logical value indicating whether using the cluster option
+while visualizing maps. Default: TRUE.}
 
-\item{hover_columns}{character with the name of the columns to use for
+\item{hover_columns}{Character vector with the name of the columns to use for
 showing location deployment information while hovering the mouse over. One
 or more from deployment columns. Use \code{NULL} to disable hovering. Default
 information:
@@ -82,16 +82,26 @@ created internally by a \verb{get_*()} function)
 }
 
 See \href{https://tdwg.github.io/camtrap-dp/data/#deployments}{section Deployment of Camtrap DP standard} for the full
-list of columns you can use}
+list of columns you can use.}
 
-\item{relative_scale}{a logical indicating whether to use a relative color
+\item{palette}{The palette name or the color function that values will be
+mapped to.
+Typically one of the following:
+\itemize{
+\item A character vector of RGB or named colors. Examples: \verb{palette(),   c("#000000", "#0000FF", "#FFFFFF"), topo.colors(10)}.
+\item the full name of a RColorBrewer palette, e.g. "BuPu" or "Greens", or
+viridis palette: \code{"viridis"}, \code{"magma"}, \code{"inferno"} or \code{"plasma"}
+For more options, see argument \code{palette} of \code{\link[leaflet:colorNumeric]{leaflet::colorNumeric()}}.
+}}
+
+\item{relative_scale}{Logical indicating whether to use a relative color
 and radius scale (\code{TRUE}) or an absolute scale (\code{FALSE}). If absolute scale
-is used, specify a valid \code{max_scale}}
+is used, specify a valid \code{max_scale}.}
 
-\item{max_scale}{a number indicating the max value used to map color
-and radius}
+\item{max_scale}{Number indicating the max value used to map color
+and radius.}
 
-\item{radius_range}{a vector of length 2 containing the lower and upper limit
+\item{radius_range}{Vector of length 2 containing the lower and upper limit
 of the circle radius. The lower value is used for deployments with zero
 feature value, i.e. no observations, no identified species, zero RAI or
 zero effort. The upper value is used for the deployment(s) with the highest
@@ -213,7 +223,28 @@ map_dep(
   effort_unit = "month"
 )
 
-# cluster disabled
+# use viridis palette
+map_dep(
+  mica,
+  "n_obs",
+  palette = "viridis"
+)
+
+# use a palette defined by color names
+map_dep(
+  mica,
+  "n_obs",
+  palette = palette(value = c("black", "blue", "white"))
+)
+
+# use a palette defined by hex colors
+map_dep(
+  mica,
+  "n_obs",
+  palette = palette(c("#000000", "#0000FF", "#FFFFFF"))
+)
+
+# disable cluster
 map_dep(mica,
   "n_species",
   cluster = FALSE

--- a/man/map_dep.Rd
+++ b/man/map_dep.Rd
@@ -223,18 +223,18 @@ map_dep(
   effort_unit = "month"
 )
 
-# use viridis palette
+# use viridis palette (viridis palettes)
 map_dep(
   mica,
   "n_obs",
   palette = "viridis"
 )
 
-# use a palette defined by color names
+# use "BuPu" color palette (RColorBrewer palettes)
 map_dep(
   mica,
   "n_obs",
-  palette = palette(value = c("black", "blue", "white"))
+  palette = "BuPu"
 )
 
 # use a palette defined by hex colors

--- a/man/map_dep.Rd
+++ b/man/map_dep.Rd
@@ -237,7 +237,14 @@ map_dep(
   palette = "BuPu"
 )
 
-# use a palette defined by hex colors
+# use a palette defined by color names
+map_dep(
+  mica,
+  "n_obs",
+  palette = palette(c("black", "blue", "white"))
+)
+
+#' # use a palette defined by hex colors
 map_dep(
   mica,
   "n_obs",

--- a/tests/testthat/test-transform_effort_to_common_units.R
+++ b/tests/testthat/test-transform_effort_to_common_units.R
@@ -1,8 +1,6 @@
-library(lubridate)
-
 test_that("transform_effort_to_common_units returns error if multiple units are given", {
   expect_error(transform_effort_to_common_units(
-    effort = duration("1day"),
+    effort = lubridate::duration("1day"),
     unit = c("day", "hour")
   ))
 })
@@ -12,18 +10,18 @@ test_that("transform_effort_to_common_units returns error if wrong unit is given
 
   # century is not allowed, maximal unit: year
   expect_error(transform_effort_to_common_units(
-    effort = duration("1day"),
+    effort = lubridate::duration("1day"),
     unit = c("century")
   ))
 })
 
 test_that("transform_effort_to_common_units transforms correctly", {
   expect_equal(transform_effort_to_common_units(
-    effort = duration("1day"),
+    effort = lubridate::duration("1day"),
     unit = "day"
   ), 1)
   expect_equal(transform_effort_to_common_units(
-    effort = duration("1hour"),
+    effort = lubridate::duration("1hour"),
     unit = "hour"
   ), 1)
 })

--- a/vignettes/visualize-deployment-features.Rmd
+++ b/vignettes/visualize-deployment-features.Rmd
@@ -257,6 +257,38 @@ map_dep(mica_less_obs,
         feature = "n_species")
 ```
 
+### Use a color palette
+
+The default color palette is a [viridis color palette](https://cran.microsoft.com/snapshot/2017-08-01/web/packages/viridis/vignettes/intro-to-viridis.html) called `"inferno"`. You can specify another viridis color palette, e.g. `"viridis"` or `"magma"`, or a [RColorBrewer](https://renenyffenegger.ch/notes/development/languages/R/packages/RColorBrewer/index) palette, e.g. `"BuPu"` or `"Oranges"`. Below we use the `viridis` color palette:
+
+```{r use_viridis}
+map_dep(
+  mica,
+  "n_obs",
+  palette = "viridis"
+)
+```
+
+We can use a palette from `RColorBrewer`, e.g. the `"BuPu"` palette:
+
+```{r use_BuPu}
+map_dep(
+  mica,
+  "n_obs",
+  palette = "BuPu"
+)
+```
+
+Another easy way to specify a palette is to create it by passing some colors as a vector to the function `palette()`, e.g. `c("black", "blue", "white")`:
+
+```{r use_black_blue_white}
+map_dep(
+  mica,
+  "n_obs",
+  palette = palette(value = c("black", "blue", "white"))
+)
+```
+
 ### Modify circle size
 
 You can also modify the upper and lower limit of the circle sizes by specifying `radius_range` (default:   `c(10,50`):


### PR DESCRIPTION
This PR implements the ideas I proposed for #34. 
Argument `palette` added to `map_dep()`. By deafult palette `inferno` is used (see example in https://github.com/inbo/camtrapdp/issues/34#issuecomment-1010077740). This palette starts with black for value 0, so it satisfies the need described in #34.
Documentation of `map_dep()` and [vignette](https://github.com/inbo/camtrapdp/blob/main/vignettes/visualize-deployment-features.Rmd) adapted.