### PR TITLE
Add markers for 0 values

### DIFF
--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -515,12 +515,21 @@ map_dep <- function(datapkg,
   # define legend values
   legend_values <- seq(from = 0, to = max_n, length.out = bins)
 
+  # define marker icon for deployments with 0 values
+  icons <- leaflet::awesomeIcons(
+    icon = 'ios-close',
+    iconColor = 'black',
+    library = 'ion',
+    markerColor = "gray"
+  )
+
   # make basic start map
   leaflet_map <-
     leaflet::leaflet(feat_df) %>%
     leaflet::addTiles()
 
-  leaflet_map %>%
+  leaflet_map <-
+    leaflet_map %>%
     leaflet::addCircleMarkers(
       lng = ~longitude,
       lat = ~latitude,
@@ -542,4 +551,19 @@ map_dep <- function(datapkg,
                 max_scale = max_scale
               )
     )
+
+  # add markers for deployments with zero values
+  zero_values <- feat_df %>%
+    filter(.data$n == 0 | is.na(.data$n))
+  if (nrow(zero_values) > 0) {
+    leaflet_map <-
+      leaflet_map %>%
+      leaflet::addAwesomeMarkers(data = zero_values,
+                                 lng = ~longitude,
+                                 lat = ~latitude,
+                                 icon = icons,
+                                 label = ~ hover_info
+      )
+  }
+  leaflet_map
 }

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -554,7 +554,7 @@ map_dep <- function(datapkg,
 
   # add markers for deployments with zero values
   zero_values <- feat_df %>%
-    filter(.data$n == 0 | is.na(.data$n))
+    dplyr::filter(.data$n == 0 | is.na(.data$n))
   if (nrow(zero_values) > 0) {
     leaflet_map <-
       leaflet_map %>%

--- a/vignettes/visualize-deployment-features.Rmd
+++ b/vignettes/visualize-deployment-features.Rmd
@@ -73,6 +73,8 @@ map_dep(mica,
         species = "Anas platyrhynchos")
 ```
 
+Notice how zero values are also visualized by a marker for ease detection.
+
 You can filter by sex:
 
 ```{r filter_sex}

--- a/vignettes/visualize-deployment-features.Rmd
+++ b/vignettes/visualize-deployment-features.Rmd
@@ -249,6 +249,10 @@ map_dep(mica_less_obs,
         feature = "n_species")
 ```
 
+Notice that this allows you to visually distinguish
+- deployments without observations: marker and grey circle
+- deployments with observations of unknown species: marker and black circle
+
 ### Use a color palette
 
 The default color palette is a [viridis color palette](https://cran.microsoft.com/snapshot/2017-08-01/web/packages/viridis/vignettes/intro-to-viridis.html) called `"inferno"`. You can specify another viridis color palette, e.g. `"viridis"` or `"magma"`, or a [RColorBrewer](https://renenyffenegger.ch/notes/development/languages/R/packages/RColorBrewer/index) palette, e.g. `"BuPu"` or `"Oranges"`. Below we use the `viridis` color palette:


### PR DESCRIPTION
This PR improves visualization of deployments where feature to visualize is equal to 0. Gray markers are added.

Examples:

![image](https://user-images.githubusercontent.com/33662631/155716340-c55e046b-c829-419e-9724-a36ed4cc6530.png)

![image](https://user-images.githubusercontent.com/33662631/155716389-0adab623-48a5-4922-bcb6-f4ad596251a3.png)

![image](https://user-images.githubusercontent.com/33662631/155716731-ab59280e-4fce-4673-8af0-65d0cf311958.png) 