### PR TITLE
Fix 82

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtrapdp
 Title: Visualize camtrap-dp formatted data
-Version: 0.8.1
+Version: 0.9.0
 Authors@R: c(
     person(given = "Damiano",
            family = "Oldoni",

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -146,7 +146,7 @@ get_custom_effort <- function(datapkg,
   } else {
     # add year column
     sum_effort <- sum_effort %>%
-      dplyr::mutate(year = lubridate::year(.data$date))
+      dplyr::mutate(year = lubridate::isoyear(.data$date))
 
     if (group_by == "year") {
       sum_effort <- sum_effort %>% dplyr::group_by(.data$year)
@@ -162,7 +162,7 @@ get_custom_effort <- function(datapkg,
     if (group_by == "week") {
       # add week column
       sum_effort <- sum_effort %>%
-        mutate(week = lubridate::week(.data$date)) %>%
+        mutate(week = lubridate::isoweek(.data$date)) %>%
         group_by(.data$year, .data$week)
     }
 

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -26,7 +26,6 @@
 #'
 #' - `begin`: Date: begin of the interval the effort is calculated over.
 #' - `effort`: The effort as number.
-#' - `effort_unit`: Character specifying the effort_unit.
 #' - `year`: Numeric, the year `begin` belongs to. This column is not present if
 #' `group_by` is `NULL`.
 #' - `month`: Numeric, the month `begin` belongs to. This column is present if
@@ -35,6 +34,7 @@
 #' `group_by` is `"week"`.
 #' - `day`: Numeric, the day `begin` belongs to. This column is present if
 #' `group_by` is `"day"`.
+#'   - `effort`: The effort as number.
 #' @family get_functions
 #' @examples
 #' # a global effort over the entire duration of the project (datapackage)

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -126,9 +126,12 @@ get_custom_effort <- function(datapkg,
     )
   )
 
-  # set start to date of the earliest deployment
+  # set start to date of the earliest deployment if NULL
   if (is.null(start)) start <- sum_effort$date[1]
+
+  # set end to date of the latest deployment if NULL
   if (is.null(end)) end <- sum_effort$date[nrow(sum_effort)]
+
   # check start earlier than end
   assertthat::assert_that(start < end,
                           msg = "start must be earlier than end.")

--- a/man/get_custom_effort.Rd
+++ b/man/get_custom_effort.Rd
@@ -20,15 +20,26 @@ get_custom_effort(
 \item{...}{filter predicates}
 
 \item{start}{Start date. Default: \code{NULL}. If \code{NULL} the earliest start date
-among all deployments is used.}
+among all deployments is used. If  \code{group_by} unit is not \code{NULL}, the
+lowest start value allowed is one group by unit before the start date of
+the earliest deployment. If this condition doesn't hold true, a warning is
+returned and the earliest start date among all deployments is used. If
+\code{group_by} unit is \code{NULL} the start must be later than or equal to the
+start date among all deployments.}
 
 \item{end}{End date. Default: \code{NULL}. If \code{NULL} the latest end date among all
-deployments is used.}
+deployments is used.  If  \code{group_by} unit is not \code{NULL}, the
+latest end value allowed is one group by unit after the end date of
+the latest deployment. If this condition doesn't hold true, a warning is
+returned and the latest end date among all deployments is used. If
+\code{group_by} unit is \code{NULL} the end must be earlier than or equal to the
+end date among all deployments.}
 
 \item{group_by}{Character, one of \code{"day"}, \code{"week"}, \code{"month"}, \code{"year"}. The
 effort is calculated at the interval rate defined in \code{group_by}. Default:
 \code{NULL}: no grouping, i.e. the entire interval from \code{start} to \code{end} is
-taken into account as a whole.}
+taken into account as a whole. A week is defined as a period of 7 days, a
+month as a period of 30 days, a year as a period of 365 days.}
 
 \item{unit}{Character, the time unit to use while returning custom effort.
 One of: \code{hour} (default), \code{day}.}
@@ -38,15 +49,7 @@ A tibble (data.frame) with following columns:
 \itemize{
 \item \code{begin}: Date: begin of the interval the effort is calculated over.
 \item \code{effort}: The effort as number.
-\item \code{effort_unit}: Character specifying the effort_unit.
-\item \code{year}: Numeric, the year \code{begin} belongs to. This column is not present if
-\code{group_by} is \code{NULL}.
-\item \code{month}: Numeric, the month \code{begin} belongs to. This column is present if
-\code{group_by} is \code{"month"} or \code{"day"}.
-\item \code{week}: Numeric, the week \code{begin} belongs to. This column is present if
-\code{group_by} is \code{"week"}.
-\item \code{day}: Numeric, the day \code{begin} belongs to. This column is present if
-\code{group_by} is \code{"day"}.
+\item \code{unit}: Character specifying the effort unit.
 }
 }
 \description{


### PR DESCRIPTION
This PR should improve the behavior of `get_custom_effort` based on suggestions of @bramdhondt.

I do not use anymore the subdivision of the time in weeks as returned by `lubridate::week()`, `lubridate::month()` or lubridate::year()`. I use the start value and then I use periods such as weeks, months and years (if `group_by` is not `NULL`):
1. a week is defined as a period of 7 days
2. a month is defined as a period of 30 days
3. a year is defined as a period of 365 days

The first row returns the `start` argument value if such value is not too "early" in comparison with the earliest deployment start. What is "too early" depends by the `group_by` unit. If `start` is more than a week before the deployment start, than a warning is returned and start is automatically set up to the deployment start. Similar behavior for other `group_by` values.
This is done to avoid trailing rows with `NA` effort. In this way informative message is returned explaining this and returning also the earliest deployment start.

Similar warning for "too late" `end` argument, if passed to the function of course. Again, this is done to avoid trailing rows with NA effort.

Notice also that the function returns now the very same output columns:
- `begin`
- `effort`
- `unit`

No more columns `year`, `month`, `week` or `day` depending on the grouping value. 

@bramdhondt: can you test this?

You can do it by running: 
```r
devtools::install_github("inbo/camtrapdp@fix-82")
```

Thanks.  
