### PR TITLE
Improve visualization of deploys with zero value

### DIFF
--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -576,7 +576,8 @@ map_dep <- function(datapkg,
                                 radius = radius_min,
                                 color = zero_values_color,
                                 stroke = TRUE,
-                                fillOpacity = 0.5 # deafult
+                                fillOpacity = 0.5, # default
+                                opacity = 0.5 # default
       )
   }
   leaflet_map

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -63,6 +63,8 @@
 #'   viridis palette: `"viridis"`, `"magma"`, `"inferno"` or `"plasma"`
 #'   For more options, see argument `palette` of [leaflet::colorNumeric()].
 #'
+#' @param zero_values_color a string identifying a color, e.g. "black", "#03F".
+#'   Default: "red".
 #' @param relative_scale Logical indicating whether to use a relative color
 #'   and radius scale (`TRUE`) or an absolute scale (`FALSE`). If absolute scale
 #'   is used, specify a valid `max_scale`.
@@ -212,6 +214,14 @@
 #'   palette = palette(c("#000000", "#0000FF", "#FFFFFF"))
 #' )
 #'
+#' #' # use a specific color for zero values other than default ("red")
+#' map_dep(
+#'   mica,
+#'   "n_obs",
+#'   life_stage = "subadult",
+#'   zero_values_color = "green"
+#' )
+#'
 #' # disable cluster
 #' map_dep(mica,
 #'   "n_species",
@@ -251,6 +261,7 @@ map_dep <- function(datapkg,
                                       "latitude", "longitude",
                                       "start", "end"),
                     palette = "inferno",
+                    zero_values_color = "red",
                     relative_scale = TRUE,
                     max_scale = NULL,
                     radius_range = c(10, 50)
@@ -515,17 +526,17 @@ map_dep <- function(datapkg,
   # define legend values
   legend_values <- seq(from = 0, to = max_n, length.out = bins)
 
-  # define marker icon for deployments with 0 values
-  icons <- leaflet::awesomeIcons(
-    icon = 'ios-close',
-    iconColor = 'black',
-    library = 'ion',
-    markerColor = "gray"
-  )
+  # # define marker icon for deployments with 0 values
+  # icons <- leaflet::awesomeIcons(
+  #   icon = 'ios-close',
+  #   iconColor = 'black',
+  #   library = 'ion',
+  #   markerColor = "gray"
+  # )
 
   # make basic start map
   leaflet_map <-
-    leaflet::leaflet(feat_df) %>%
+    leaflet::leaflet(data = feat_df %>% dplyr::filter(.data$n > 0)) %>%
     leaflet::addTiles()
 
   leaflet_map <-
@@ -558,11 +569,14 @@ map_dep <- function(datapkg,
   if (nrow(zero_values) > 0) {
     leaflet_map <-
       leaflet_map %>%
-      leaflet::addAwesomeMarkers(data = zero_values,
-                                 lng = ~longitude,
-                                 lat = ~latitude,
-                                 icon = icons,
-                                 label = ~ hover_info
+      leaflet::addCircleMarkers(data = zero_values,
+                                lng = ~longitude,
+                                lat = ~latitude,
+                                label = ~ hover_info,
+                                radius = radius_min,
+                                color = zero_values_color,
+                                stroke = TRUE,
+                                fillOpacity = 0.5 # deafult
       )
   }
   leaflet_map

--- a/man/map_dep.Rd
+++ b/man/map_dep.Rd
@@ -16,6 +16,7 @@ map_dep(
   hover_columns = c("n", "species", "deploymentID", "locationID", "locationName",
     "latitude", "longitude", "start", "end"),
   palette = "inferno",
+  zero_values_color = "red",
   relative_scale = TRUE,
   max_scale = NULL,
   radius_range = c(10, 50)
@@ -91,6 +92,9 @@ Typically one of the following:
 viridis palette: \code{"viridis"}, \code{"magma"}, \code{"inferno"} or \code{"plasma"}
 For more options, see argument \code{palette} of \code{\link[leaflet:colorNumeric]{leaflet::colorNumeric()}}.
 }}
+
+\item{zero_values_color}{a string identifying a color, e.g. "black", "#03F".
+Default: "red".}
 
 \item{relative_scale}{Logical indicating whether to use a relative color
 and radius scale (\code{TRUE}) or an absolute scale (\code{FALSE}). If absolute scale
@@ -241,6 +245,14 @@ map_dep(
   mica,
   "n_obs",
   palette = palette(c("#000000", "#0000FF", "#FFFFFF"))
+)
+
+#' # use a specific color for zero values other than default ("red")
+map_dep(
+  mica,
+  "n_obs",
+  life_stage = "subadult",
+  zero_values_color = "green"
 )
 
 # disable cluster

--- a/vignettes/visualize-deployment-features.Rmd
+++ b/vignettes/visualize-deployment-features.Rmd
@@ -287,6 +287,33 @@ map_dep(
 )
 ```
 
+### Use a specific color for zero values
+
+You can pass to `zero_value_colors` argument your own color, e.g. `"green"` (color name) or `"#03F"` (hex). Modifying the default  value (`"red"`) can be useful as the color of deployments with zero values can be sometimes too similar to one of the colors used in the palette.
+
+Use a color name: 
+
+```{r specify_zero_colors_value_example_1}
+map_dep(
+  mica,
+  "n_obs",
+  life_stage = "subadult",
+  zero_values_color = "green"
+)
+```
+
+Use a hexadecimal color:
+
+```{r specify_zero_colors_value_example_2}
+map_dep(
+  mica,
+  "n_obs",
+  life_stage = "subadult",
+  zero_values_color = "#00A58F"
+)
+```
+
+
 ### Modify circle size
 
 You can also modify the upper and lower limit of the circle sizes by specifying `radius_range` (default:   `c(10,50`):


### PR DESCRIPTION
Based on preference of @jimcasaer in https://github.com/inbo/camtrapdp/issues/34#issuecomment-1058432051, this PR:
1. Adds argument `zero_values_color` to `map_dep()` function with deafult value `"red"` (deafult `fillOpacity` and `opacity` used, i.e. 0.5)
2. Updates documentation of `map_dep()`
3. Adds section about use of `zero_values_color` in vignette [visualize-deployment-features.Rmd](https://github.com/inbo/camtrapdp/blob/special-color-zeros/vignettes/visualize-deployment-features.Rmd)