### PR TITLE
Add clustering of non zero values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtrapdp
 Title: Visualize camtrap-dp formatted data
-Version: 0.9.0
+Version: 0.10.0
 Authors@R: c(
     person(given = "Damiano",
            family = "Oldoni",

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -577,7 +577,7 @@ map_dep <- function(datapkg,
                                 color = zero_values_color,
                                 stroke = TRUE,
                                 fillOpacity = 0.5, # default
-                                opacity = 0.5 # default
+        clusterOptions = if (cluster == TRUE) leaflet::markerClusterOptions() else NULL
       )
   }
   leaflet_map

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -536,7 +536,8 @@ map_dep <- function(datapkg,
 
   # make basic start map
   leaflet_map <-
-    leaflet::leaflet(data = feat_df %>% dplyr::filter(.data$n > 0)) %>%
+    leaflet::leaflet(data = feat_df %>%
+                       dplyr::filter(.data$n > 0 | is.na(.data$n))) %>%
     leaflet::addTiles()
 
   leaflet_map <-
@@ -565,18 +566,20 @@ map_dep <- function(datapkg,
 
   # add markers for deployments with zero values
   zero_values <- feat_df %>%
-    dplyr::filter(.data$n == 0 | is.na(.data$n))
+    dplyr::filter(.data$n == 0)
   if (nrow(zero_values) > 0) {
     leaflet_map <-
       leaflet_map %>%
-      leaflet::addCircleMarkers(data = zero_values,
-                                lng = ~longitude,
-                                lat = ~latitude,
-                                label = ~ hover_info,
-                                radius = radius_min,
-                                color = zero_values_color,
-                                stroke = TRUE,
-                                fillOpacity = 0.5, # default
+      leaflet::addCircleMarkers(
+        data = zero_values,
+        lng = ~longitude,
+        lat = ~latitude,
+        label = ~ hover_info,
+        radius = radius_min,
+        color = zero_values_color,
+        stroke = TRUE,
+        fillOpacity = 0.5, # default
+        opacity = 0.5, # default
         clusterOptions = if (cluster == TRUE) leaflet::markerClusterOptions() else NULL
       )
   }

--- a/vignettes/visualize-deployment-features.Rmd
+++ b/vignettes/visualize-deployment-features.Rmd
@@ -235,7 +235,7 @@ map_dep(mica,
         hover_columns = NULL)
 ```
 
-### Visualize deployments without detected aniamals
+### Visualize deployments without detected animals
 
 It can happen that some deployments didn't observe any animal. While visualizing the number of species, they are shown in the map as red circles as deployments with zero values and a message is returned to the R console:
 

--- a/vignettes/visualize-deployment-features.Rmd
+++ b/vignettes/visualize-deployment-features.Rmd
@@ -73,7 +73,7 @@ map_dep(mica,
         species = "Anas platyrhynchos")
 ```
 
-Notice how zero values are also visualized by a marker for ease detection.
+Notice how zero values are also visualized by a specific circle marker for ease detection. Color: red by default.
 
 You can filter by sex:
 
@@ -237,7 +237,7 @@ map_dep(mica,
 
 ### Visualize deployments without detected aniamals
 
-It can happen that some deployments didn't observe any animal. While visualizing the number of species, they are shown in the map as gray circles and a message is returned to the R console:
+It can happen that some deployments didn't observe any animal. While visualizing the number of species, they are shown in the map as red circles as deployments with zero values and a message is returned to the R console:
 
 ```{r show_deployments_without_observations}
 # create data package with less observations
@@ -252,8 +252,8 @@ map_dep(mica_less_obs,
 ```
 
 Notice that this allows you to visually distinguish
-- deployments without observations: marker and grey circle
-- deployments with observations of unknown species: marker and black circle
+- deployments without observations: grey circle as the number of species, the feature value, is NA
+- deployments with only observations of unknown species: red circle as the number of species, the feature value, is zero
 
 ### Use a color palette
 


### PR DESCRIPTION
Layer with non zero values deployments allows clustering as well (default). Argument `cluster` works on both layers (non zero and zero deploys).
Vignette visualization improved as well: removed typo and old reference to the "ugly" big markers.
