### PR TITLE
Fix #89

### DIFF
--- a/R/get_record_table.R
+++ b/R/get_record_table.R
@@ -5,7 +5,8 @@
 #' within the camtrapR package: see article
 #' https://jniedballa.github.io/camtrapR/articles/camtrapr3.html. See also the
 #' camtrapR's function documentation
-#' [recordTable](https://jniedballa.github.io/camtrapR/reference/recordTable.html)
+#' [recordTable](https://jniedballa.github.io/camtrapR/reference/recordTable.html).
+#' **Note**: All dates and times are expressed in UTC format.
 #'
 #' @param datapkg a camera trap data package object, as returned by
 #'   `read_camtrap_dp()`.
@@ -40,9 +41,9 @@
 #'   defined  in argument `stationCol`
 #'   2. `Species`: character, the scientific name of the observed species
 #'   3. `DateTimeOriginal`: datetime object, as found in column `timestamp` of
-#'   `observations`
-#'   4. `Date`: date object, the date part of `DateTimeOriginal`
-#'   5. `Time`: character, the time part of `DateTimeOriginal`
+#'   `observations`, in UTC format.
+#'   4. `Date`: date object, the date part of `DateTimeOriginal`, in UTC format.
+#'   5. `Time`: character, the time part of `DateTimeOriginal` in UTC format.
 #'   6. `delta.time.secs`: numeric, the duration in seconds from the previous
 #'   independent record of a given species at a certain location
 #'   7. `delta.time.mins`: numeric, the duration in minutes from the previous

--- a/R/read_camtrap_dp.R
+++ b/R/read_camtrap_dp.R
@@ -1,21 +1,23 @@
 #' Read camtrap-dp formatted data
 #'
 #' This function reads camera trap data formatted following the [Camera Trap
-#' Data Package (Camtrap DP)](https://github.com/tdwg/camtrap-dp) format.
+#' Data Package (Camtrap DP)](https://github.com/tdwg/camtrap-dp) format. The
+#' function is built upon the functions \link[frictionless]{read_package} and
+#' \link[frictionless]{read_resource}. This means a.o. that all datetime
+#' information included in the camera trap data package is automatically
+#' transformed to UTC (Coordinated Universal Time).
 #'
 #' Vernacular names are typically used while working with camera trap
 #' _observations_, so they are added to the observations as defined in the
 #' metadata (slot `taxonomic`), if present.
 #'
 #' @param file Path or URL to a `datapackage.json` file.
-#' @param media If `TRUE`, read media records into memory. If `FALSE`,
-#'   ignore media file to speed up reading larger Camtrap DP packages.
+#' @param media If `TRUE`, read media records into memory. If `FALSE`, ignore
+#'   media file to speed up reading larger Camtrap DP packages.
 #' @param path Path to the directory containing the datapackage. Use  `file`
 #'   with path or URL to a `datapackage.json` file instead.
-#' @return A list containing three (tibble) data.frames:
-#'   1. `observations`
-#'   2. `deployments`
-#'   3. `media`
+#' @return A list containing three (tibble) data.frames: 1. `observations` 2.
+#'   `deployments` 3. `media`
 #'
 #'   and a list with metadata: `datapackage`
 #'

--- a/man/get_record_table.Rd
+++ b/man/get_record_table.Rd
@@ -47,9 +47,9 @@ records. Some more details about the columns returned:
 defined  in argument \code{stationCol}
 \item \code{Species}: character, the scientific name of the observed species
 \item \code{DateTimeOriginal}: datetime object, as found in column \code{timestamp} of
-\code{observations}
-\item \code{Date}: date object, the date part of \code{DateTimeOriginal}
-\item \code{Time}: character, the time part of \code{DateTimeOriginal}
+\code{observations}, in UTC format.
+\item \code{Date}: date object, the date part of \code{DateTimeOriginal}, in UTC format.
+\item \code{Time}: character, the time part of \code{DateTimeOriginal} in UTC format.
 \item \code{delta.time.secs}: numeric, the duration in seconds from the previous
 independent record of a given species at a certain location
 \item \code{delta.time.mins}: numeric, the duration in minutes from the previous
@@ -70,7 +70,8 @@ and so tabulating species records. The record table is a concept developed
 within the camtrapR package: see article
 https://jniedballa.github.io/camtrapR/articles/camtrapr3.html. See also the
 camtrapR's function documentation
-\href{https://jniedballa.github.io/camtrapR/reference/recordTable.html}{recordTable}
+\href{https://jniedballa.github.io/camtrapR/reference/recordTable.html}{recordTable}.
+\strong{Note}: All dates and times are expressed in UTC format.
 }
 \examples{
 get_record_table(mica)

--- a/man/read_camtrap_dp.Rd
+++ b/man/read_camtrap_dp.Rd
@@ -9,24 +9,24 @@ read_camtrap_dp(file = NULL, media = TRUE, path = lifecycle::deprecated())
 \arguments{
 \item{file}{Path or URL to a \code{datapackage.json} file.}
 
-\item{media}{If \code{TRUE}, read media records into memory. If \code{FALSE},
-ignore media file to speed up reading larger Camtrap DP packages.}
+\item{media}{If \code{TRUE}, read media records into memory. If \code{FALSE}, ignore
+media file to speed up reading larger Camtrap DP packages.}
 
 \item{path}{Path to the directory containing the datapackage. Use  \code{file}
 with path or URL to a \code{datapackage.json} file instead.}
 }
 \value{
-A list containing three (tibble) data.frames:
-\enumerate{
-\item \code{observations}
-\item \code{deployments}
-\item \code{media}
-}
+A list containing three (tibble) data.frames: 1. \code{observations} 2.
+\code{deployments} 3. \code{media}
 
 and a list with metadata: \code{datapackage}
 }
 \description{
-This function reads camera trap data formatted following the \href{https://github.com/tdwg/camtrap-dp}{Camera Trap Data Package (Camtrap DP)} format.
+This function reads camera trap data formatted following the \href{https://github.com/tdwg/camtrap-dp}{Camera Trap Data Package (Camtrap DP)} format. The
+function is built upon the functions \link[frictionless]{read_package} and
+\link[frictionless]{read_resource}. This means a.o. that all datetime
+information included in the camera trap data package is automatically
+transformed to UTC (Coordinated Universal Time).
 }
 \details{
 Vernacular names are typically used while working with camera trap


### PR DESCRIPTION
This PR improves the documentation of `read_camtrap_dp()` and `get_record_table()` making very clear how datetime information is read within this package (read_camtrap_dp()) and how it is returned in the record table (`get_record_table()`).