### PR TITLE
Don't use `"."` as default dir in `write_dwc()`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,4 +25,4 @@ doi: ~
 license: MIT
 repository-code: https://github.com/inbo/camtrapdp
 type: software
-version: 0.2.0
+version: 0.2.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtrapdp
 Title: Read and Manipulate Camera Trap Data Packages
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
     person("Peter", "Desmet", , "peter.desmet@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8442-8025")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# camtrapdp 0.2.1
+
+* `write_dwc()` no longer writes to `"."` by default, since is not allowed by CRAN policies. The user needs to explicitly define a directory (#79).
+
 # camtrapdp 0.2.0
 
 * New function `read_camtrapdp()` reads data files from a Camtrap DP into memory (#9). It will make the data easier to use, by assigning taxonomic information (found in the metadata) to the observations and `eventID`s (found in the observations) to the media (#37).

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -49,7 +49,7 @@
 #'
 #' # Clean up (don't do this if you want to keep your files)
 #' unlink("my_directory", recursive = TRUE)
-write_dwc <- function(x, directory = ".") {
+write_dwc <- function(x, directory) {
   check_camtrapdp(x)
 
   # Set properties from metadata or default to NA when missing

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/inbo/camtrapdp",
   "issueTracker": "https://github.com/inbo/camtrapdp/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -181,7 +181,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "188.574KB",
+  "fileSize": "188.364KB",
   "releaseNotes": "https://github.com/inbo/camtrapdp/blob/master/NEWS.md",
   "readme": "https://github.com/inbo/camtrapdp/blob/main/README.md",
   "contIntegration": ["https://github.com/inbo/camtrapdp/actions/workflows/R-CMD-check.yaml", "https://app.codecov.io/gh/inbo/camtrapdp/"],

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,9 @@
+## Resubmission
+
+This is a resubmission. In this version I have:
+
+* Updated write_dwc() so it no longer writes to the user's home filespace by default. The directory needs to be explicitly provided by the user. Tests write to tempdir().
+
 ## R CMD check results
 
 0 errors | 0 warnings | 1 note

--- a/man/write_dwc.Rd
+++ b/man/write_dwc.Rd
@@ -4,7 +4,7 @@
 \alias{write_dwc}
 \title{Transform a Camera Trap Data Package to a Darwin Core Archive}
 \usage{
-write_dwc(x, directory = ".")
+write_dwc(x, directory)
 }
 \arguments{
 \item{x}{Camera Trap Data Package object, as returned by


### PR DESCRIPTION
Cf. CRAN policies