### PR TITLE
115 add ticks to timeshift message

### DIFF
--- a/R/shift_time.R
+++ b/R/shift_time.R
@@ -132,11 +132,10 @@ shift_time <- function(x, deployment_id, duration) {
   # Return message
   cli::cli_inform(
     c(
-      "v" =
-        "Date-times in selected deployments, media and observations were shifted
-        by {.val {duration}}. E.g. {.val {current_datetime}} is now
-        {.val {new_datetime}}."
-      ),
+      "v" = "Date-times in selected deployments, media and observations were
+             shifted by {.val {duration}}. E.g. {.val {current_datetime}} is now
+             {.val {new_datetime}}."
+    ),
     class = "camtrapdp_message_shift_time"
   )
 

--- a/R/shift_time.R
+++ b/R/shift_time.R
@@ -131,9 +131,12 @@ shift_time <- function(x, deployment_id, duration) {
 
   # Return message
   cli::cli_inform(
-    "Date-times in selected deployments, media and observations were shifted by
-     {.val {duration}}. E.g. {.val {current_datetime}} is now
-     {.val {new_datetime}}.",
+    c(
+      "v" =
+        "Date-times in selected deployments, media and observations were shifted
+        by {.val {duration}}. E.g. {.val {current_datetime}} is now
+        {.val {new_datetime}}."
+      ),
     class = "camtrapdp_message_shift_time"
   )
 

--- a/tests/testthat/test-shift_time.R
+++ b/tests/testthat/test-shift_time.R
@@ -152,8 +152,8 @@ test_that("shift_time() supports duration() and difftime()", {
   deployment_id <- "00a2c20d"
   duration <- lubridate::duration(-4, units = "hours")
   difftime <- difftime("2024-04-01 00:00:00", "2024-04-01 04:00:00", tz = "UTC")
-  x_duration <- suppressWarnings(shift_time(x, deployment_id, duration))
-  x_difftime <- suppressWarnings(shift_time(x, deployment_id, difftime))
+  x_duration <- suppressMessages(shift_time(x, deployment_id, duration))
+  x_difftime <- suppressMessages(shift_time(x, deployment_id, difftime))
 
   expect_identical(deployments(x_duration), deployments(x_difftime))
   expect_identical(media(x_duration), media(x_difftime))


### PR DESCRIPTION
Small PR to add a ✔️ to the `shift_time()` messaging similar to `cli::cli_alert_success()`