### PR TITLE
Create output if taxonID is missing

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -20,3 +20,19 @@ mutate_when_missing <- function(.data, ...) {
   }
   return(.data)
 }
+
+#' Expand columns
+#'
+#' Expands a data frame with columns. Added columns will have `NA_character_`
+#' values, existing columns of the same name will not be overwritten.
+#'
+#' @param df A data frame.
+#' @param colnames A character vector of column names.
+#' @return Data frame expanded with columns that were not yet present.
+#' @family helper functions
+#' @noRd
+expand_cols <- function(df, colnames) {
+  cols_to_add <- setdiff(colnames, colnames(df))
+  df[, cols_to_add] <- NA_character_
+  return(df)
+}

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -146,7 +146,7 @@ write_dwc <- function(x, directory) {
       eventRemarks = paste0(
         # E.g. "camera trap with bait near burrow | tags: <t1, t2> | <comment>"
         dplyr::if_else(
-          .data$baitUse,
+          as.logical(.data$baitUse),
           "camera trap with bait",
           "camera trap without bait"
         ),
@@ -210,7 +210,10 @@ write_dwc <- function(x, directory) {
         dplyr::if_else(
           is.na(.data$classificationProbability),
           "",
-          paste0(" with ", .data$classificationProbability * 100, "% certainty")
+          paste0(
+            " with ", as.numeric(.data$classificationProbability) * 100,
+            "% certainty"
+          )
         )
       ),
       taxonID = .data$taxon.taxonID,
@@ -270,7 +273,7 @@ write_dwc <- function(x, directory) {
       accessURI = .data$filePath,
       `dc:format` = .data$fileMediatype,
       serviceExpectation = dplyr::if_else(
-        .data$filePublic,
+        as.logical(.data$filePublic),
         "online",
         "authenticate"
       )

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -83,10 +83,16 @@ write_dwc <- function(x, directory) {
   # Start transformation
   cli::cli_h2("Transforming data to Darwin Core")
 
+  # Read data and add optional columns that are used in transformation
+ deployments <- deployments(x)
+ media <- media(x)
+ observations_cols <- c("taxon.taxonID")
+ observations <- expand_cols(observations(x), observations_cols)
+
   # Create Darwin Core Occurrence core
   occurrence <-
-    observations(x) %>%
-    dplyr::left_join(deployments(x), by = "deploymentID") %>%
+    observations %>%
+    dplyr::left_join(deployments, by = "deploymentID") %>%
     dplyr::arrange(.data$deploymentID, .data$eventStart) %>%
     dplyr::mutate(
       .keep = "none",
@@ -227,15 +233,15 @@ write_dwc <- function(x, directory) {
 
   # Create Audubon/Audiovisual Media Description extension
   multimedia <-
-    observations(x) %>%
+    observations %>%
     dplyr::select(-"mediaID") %>%
     dplyr::left_join(
-      media(x),
+      media,
       by = c("deploymentID", "eventID"),
       relationship = "many-to-many" # Silence warning
     ) %>%
     dplyr::left_join(
-      deployments(x),
+      deployments,
       by = "deploymentID"
     ) %>%
     dplyr::arrange(.data$deploymentID, .data$timestamp, .data$fileName) %>%

--- a/tests/testthat/test-write_dwc.R
+++ b/tests/testthat/test-write_dwc.R
@@ -109,3 +109,15 @@ test_that("write_dwc() returns files that comply with the info in meta.xml", {
   expect_meta_match(file.path(temp_dir, "occurrence.csv"))
   expect_meta_match(file.path(temp_dir, "multimedia.csv"))
 })
+
+test_that("write_dwc() returns output when taxonID is missing", {
+  skip_if_offline()
+  x <- example_dataset()
+  optional_cols <- c("taxon.taxonID")
+  observations(x) <-
+    dplyr::select(observations(x), -dplyr::all_of(optional_cols))
+  temp_dir <- file.path(tempdir(), "dwc")
+  on.exit(unlink(temp_dir, recursive = TRUE))
+
+  expect_no_error(suppressMessages(write_dwc(x, temp_dir)))
+})


### PR DESCRIPTION
Fix #125.

Initially I opted to assume that no columns are defined, i.e. that all columns should be added with `expand_cols()` in `write_dwc()` (cf. movepub). That doesn't fully work however, since the `filter_` functions called in `write_dwc()` already expect some columns to be present. So `expand_cols()` is better called elsewhere.

The best place would be in `read_camtrapdp()`, where we could use `expand_cols()` to add all possible Camtrap DP columns. That doesn't help with `taxon.taxonID` though and the design of the Camtrap DP standard currently dictates that all columns should be present. So that's a bridge we should cross when Camtrap DP allows for optional columns.

This PR thus only adds the optional columns that are used in the Darwin Core transformation. At the moment, that is only `taxon.taxonID`.