### PR TITLE
`write_dwc()`: Only filter on `event` if `observationType` includes event

### DIFF
--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -76,11 +76,10 @@ write_dwc <- function(x, directory) {
     purrr::pluck(x, "coordinatePrecision", .default = NA_character_)
 
   # Filter dataset on observations (also affects media)
-  x <- filter_observations(
-    x,
-    .data$observationLevel == "event",
-    .data$observationType == "animal"
-  )
+  x <- filter_observations(x, .data$observationType == "animal")
+  if ("event" %in% x$project$observationLevel) {
+    x <- filter_observations(x, .data$observationLevel == "event")
+  }
 
   # Start transformation
   cli::cli_h2("Transforming data to Darwin Core")

--- a/camtrapdp.Rproj
+++ b/camtrapdp.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: acc36473-5f70-44d7-bd93-5b2ebcdde2d2
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
See issue https://github.com/gbif/ipt/issues/2709