### PR TITLE
update to EML 2.2.0

### DIFF
--- a/R/write_eml.R
+++ b/R/write_eml.R
@@ -76,19 +76,20 @@ write_eml <- function(x, directory, derived_paragraph = TRUE) {
   eml$dataset$title <- x$title
 
   # Set abstract, with optional extra paragraph
-  para <- x$description
+  para <- x$description %>%
+    # Add <p></p> tags to each paragraph
+    purrr::map_chr(~ paste0("<p>", ., "</p>"))
   if (derived_paragraph) {
     last_para <- paste0(
-      # Add span to circumvent https://github.com/ropensci/EML/issues/342
-      "<span></span>Data have been standardized to Darwin Core using the ",
+      "<p>Data have been standardized to Darwin Core using the ",
       "<a href=\"https://inbo.github.io/camtrapdp/\">camtrapdp</a> R package ",
       "and only include observations (and associated media) of animals. ",
       "Excluded are records that document blank or unclassified media, ",
-      "vehicles and observations of humans."
+      "vehicles and observations of humans.</p>"
     )
-    para <- append(para, paste0("<![CDATA[", last_para, "]]>"))
+    para <- append(para, last_para)
   }
-  eml$dataset$abstract$para <- para
+  eml$dataset$abstract$para <- paste0(para, collapse = "")
 
   # Set update frequency (requires a description, even if empty)
   eml$dataset$maintenance <- list(

--- a/tests/testthat/_snaps/write_eml/eml.xml
+++ b/tests/testthat/_snaps/write_eml/eml.xml
@@ -47,8 +47,10 @@
     </metadataProvider>
     <pubDate>2023-02-06</pubDate>
     <abstract>
-      <para>MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany is an occurrence dataset published by the Research Institute of Nature and Forest (INBO). It is part of the LIFE project MICA, in which innovative techniques are tested for a more efficient control of muskrat and coypu populations, both invasive species. This dataset is a sample of the original dataset and serves as an example of a Camera Trap Data Package (Camtrap DP).</para>
-      <para><![CDATA[<span></span>Data have been standardized to Darwin Core using the <a href="https://inbo.github.io/camtrapdp/">camtrapdp</a> R package and only include observations (and associated media) of animals. Excluded are records that document blank or unclassified media, vehicles and observations of humans.]]></para>
+      <para>
+        <p>MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany is an occurrence dataset published by the Research Institute of Nature and Forest (INBO). It is part of the LIFE project MICA, in which innovative techniques are tested for a more efficient control of muskrat and coypu populations, both invasive species. This dataset is a sample of the original dataset and serves as an example of a Camera Trap Data Package (Camtrap DP).</p>
+        <p>Data have been standardized to Darwin Core using the <a href="https://inbo.github.io/camtrapdp/">camtrapdp</a> R package and only include observations (and associated media) of animals. Excluded are records that document blank or unclassified media, vehicles and observations of humans.</p>
+      </para>
     </abstract>
     <keywordSet>
       <keyword>Occurrence</keyword>


### PR DESCRIPTION
The IPT (v 3.1.0) updated from EML 2.1.1 to EML 2.2.0, solving https://github.com/ropensci/EML/issues/342. We update our scripts accordingly.