### PR TITLE
Attach citation to $gbif$citation

### DIFF
--- a/R/write_eml.R
+++ b/R/write_eml.R
@@ -208,8 +208,7 @@ write_eml <- function(x, directory, derived_paragraph = TRUE) {
   )
 
   # Set bibliographic citation (can be NULL)
-  eml$additionalMetadata$metadata$gbif$bibliography$citation <-
-    x$bibliographicCitation
+  eml$additionalMetadata$metadata$gbif$citation <- x$bibliographicCitation
 
   # Set external link = project URL (can be NULL)
   project_url <- x$project$path

--- a/tests/testthat/_snaps/write_eml/eml.xml
+++ b/tests/testthat/_snaps/write_eml/eml.xml
@@ -184,9 +184,7 @@
   <additionalMetadata>
     <metadata>
       <gbif>
-        <bibliography>
-          <citation>Desmet P, Neukermans A, Van der beeck D, Cartuyvels E (2022). Sample from: MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany. Version 1.0.1. Research Institute for Nature and Forest (INBO). Dataset. https://camtrap-dp.tdwg.org/example/</citation>
-        </bibliography>
+        <citation>Desmet P, Neukermans A, Van der beeck D, Cartuyvels E (2022). Sample from: MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany. Version 1.0.1. Research Institute for Nature and Forest (INBO). Dataset. https://camtrap-dp.tdwg.org/example/</citation>
       </gbif>
     </metadata>
   </additionalMetadata>


### PR DESCRIPTION
Not `$gbif$bibliography$citation`. This was an error.

@sannegovaert can you verify this is not an issue in:

- [x] movepub::write_eml()
- [x] etn::write_dwc()

I assume not, because we don't use `x$bibliographicCitation`