### PR TITLE
Add x$references to bibliography

### DIFF
--- a/R/write_eml.R
+++ b/R/write_eml.R
@@ -211,6 +211,10 @@ write_eml <- function(x, directory, derived_paragraph = TRUE) {
   eml$additionalMetadata$metadata$gbif$bibliography$citation <-
     x$bibliographicCitation
 
+  # Set bibliography (can be NULL)
+  references <- as.list(x$references) %>% rlang::set_names("citation")
+  eml$additionalMetadata$metadata$gbif$bibliography <- references
+
   # Set external link = project URL (can be NULL)
   project_url <- x$project$path
   if (!is.null(project_url)) {


### PR DESCRIPTION
Aims to fix #121. The EML object returned by `write_eml()` is correct:

``` r
library(camtrapdp)
x <- example_dataset()
x$references <- c("ref 1", "ref 2")
eml <- write_eml(x, ".")
#> 
#> ── Writing file ──
#> 
#> • './eml.xml'
eml$additionalMetadata
#> $metadata
#> $metadata$gbif
#> $metadata$gbif$bibliography
#> $metadata$gbif$bibliography$citation
#> [1] "ref 1"
#> 
#> $metadata$gbif$bibliography$citation
#> [1] "ref 2"
```

<sup>Created on 2025-06-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

But the XML file doesn't seem to like that the elements have the same name and coverts it to:

```xml
<additionalMetadata>
    <metadata>
      <gbif>
        <bibliography>
          <citation>ref 1</citation>
          <citation.1>ref 2</citation.1>
        </bibliography>
      </gbif>
    </metadata>
  </additionalMetadata>
```

I'm not sure where that occurs (`EML::write_eml()` or underlying `xml2::write_xml()`) and how to resolve this. See also https://github.com/ropensci/EML/issues/351