### PR TITLE
Avoid null values in `datapackage.json`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # camtrapdp (development version)
 
 * `read_camtrapdp()` now upgrades datasets to Camtrap DP 1.0.2 (#183).
+* `write_camtrapdp()` now removes NA values nested in `x$taxonomic` (#186).
 
 # camtrapdp 0.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # camtrapdp (development version)
 
 * `read_camtrapdp()` now upgrades datasets to Camtrap DP 1.0.2 (#183).
-* `write_camtrapdp()` now removes NA values nested in `x$taxonomic` and `x$contributors` (#186).
+* `write_camtrapdp()` now removes properties with `NA` values from `x$taxonomic` and `x$contributors` which caused `datapackage.json` to be invalid (#186).
 
 # camtrapdp 0.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # camtrapdp (development version)
 
 * `read_camtrapdp()` now upgrades datasets to Camtrap DP 1.0.2 (#183).
-* `write_camtrapdp()` now removes NA values nested in `x$taxonomic` (#186).
+* `write_camtrapdp()` now removes NA values nested in `x$taxonomic` and `x$contributors` (#186).
 
 # camtrapdp 0.4.0
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -119,3 +119,33 @@ create_eml_contributors <- function(contributors) {
     onlineUrl = .x$path
   ))
 }
+
+#' Recursively remove NA values from a nested list
+#'
+#' Removes all elements that are NA at any depth. It works recursively, so any
+#' NA inside sublists will also be removed.
+#'
+#' @param nested_list A (possibly nested) list to clean of NA values.
+#' @return A list of the same structure as nested_list, but with all NA elements
+#' removed.
+#' @family helper functions
+#' @noRd
+#' @examples
+#' test_list <- list(
+#'   a = NA,
+#'   b = list(
+#'     c = 1,
+#'     d = NA
+#'   ),
+#'   e = 2
+#' )
+remove_na_recursive <- function(nested_list) {
+  if (is.list(nested_list)) {
+    purrr::map(nested_list, remove_na_recursive) %>%
+      purrr::compact()
+  } else if (is.na(nested_list)) {
+    NULL
+  } else {
+    nested_list
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -120,32 +120,29 @@ create_eml_contributors <- function(contributors) {
   ))
 }
 
-#' Recursively remove NA values from a nested list
+#' Clean list
 #'
-#' Removes all elements that are NA at any depth. It works recursively, so any
-#' NA inside sublists will also be removed.
+#' Removes all elements from a list that meet a criterion function, e.g.
+#' [is.null()] for empty elements.
+#' Removal can be recursive to guarantee elements are removed at any level.
+#' Function is copied and adapted from `rlist::list.clean()` (MIT licensed), to
+#' avoid requiring full `rlist` dependency.
 #'
-#' @param nested_list A (possibly nested) list to clean of NA values.
-#' @return A list of the same structure as nested_list, but with all NA elements
-#' removed.
+#' @param x List or vector.
+#' @param fun Function returning `TRUE` for elements that should be removed.
+#' @param recursive Whether list should be cleaned recursively.
+#' @return Cleaned list.
 #' @family helper functions
 #' @noRd
-#' @examples
-#' test_list <- list(
-#'   a = NA,
-#'   b = list(
-#'     c = 1,
-#'     d = NA
-#'   ),
-#'   e = 2
-#' )
-remove_na_recursive <- function(nested_list) {
-  if (is.list(nested_list)) {
-    purrr::map(nested_list, remove_na_recursive) %>%
-      purrr::compact()
-  } else if (is.na(nested_list)) {
-    NULL
-  } else {
-    nested_list
+clean_list <- function(x, fun = is.null, recursive = FALSE) {
+  if (recursive) {
+    x <- lapply(x, function(item) {
+      if (is.list(item)) {
+        clean_list(item, fun, recursive = TRUE)
+      } else {
+        item
+      }
+    })
   }
+  "[<-"(x, vapply(x, fun, logical(1L)), NULL)
 }

--- a/R/write_camtrapdp.R
+++ b/R/write_camtrapdp.R
@@ -63,6 +63,11 @@ write_camtrapdp <- function(x, directory, ...) {
     function(x) any(is.na(x)) || length(x) == 0L,
     recursive = TRUE
   )
+  x$contributors <- clean_list(
+    x$contributors,
+    function(x) any(is.na(x)) || length(x) == 0L,
+    recursive = TRUE
+  )
 
   # Write files
   frictionless::write_package(x, directory, ...)

--- a/R/write_camtrapdp.R
+++ b/R/write_camtrapdp.R
@@ -57,8 +57,12 @@ write_camtrapdp <- function(x, directory, ...) {
   # Remove data
   x$data <- NULL
 
-  # Remove NA values in x$taxonomic to avoid validation error in frictionless
-  x$taxonomic <- purrr::map(x$taxonomic, remove_na_recursive)
+  # Remove elements that are NA or empty list
+  x$taxonomic <- clean_list(
+    x$taxonomic,
+    function(x) any(is.na(x)) || length(x) == 0L,
+    recursive = TRUE
+  )
 
   # Write files
   frictionless::write_package(x, directory, ...)

--- a/R/write_camtrapdp.R
+++ b/R/write_camtrapdp.R
@@ -58,7 +58,7 @@ write_camtrapdp <- function(x, directory, ...) {
   x$data <- NULL
 
   # Remove NA values in x$taxonomic to avoid validation error in frictionless
-  x$taxonomic <- purrr::map(x$taxonomic, ~ .x[!is.na(.x)])
+  x$taxonomic <- purrr::map(x$taxonomic, remove_na_recursive)
 
   # Write files
   frictionless::write_package(x, directory, ...)

--- a/man/read_camtrapdp.Rd
+++ b/man/read_camtrapdp.Rd
@@ -84,7 +84,7 @@ are tabular.
 }
 
 \examples{
-file <- "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/example/datapackage.json"
+file <- "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/example/datapackage.json"
 x <- read_camtrapdp(file)
 x
 }

--- a/tests/testthat/_snaps/write_camtrapdp/datapackage.json
+++ b/tests/testthat/_snaps/write_camtrapdp/datapackage.json
@@ -47,6 +47,8 @@
   "contributors": [
     {
       "title": "Axel Neukermans",
+      "firstName": "Axel",
+      "lastName": "Neukermans",
       "email": "axel.neukermans@inbo.be",
       "path": "https://orcid.org/0000-0003-0272-9180",
       "role": "contributor",
@@ -54,16 +56,22 @@
     },
     {
       "title": "Danny Van der beeck",
+      "firstName": "Danny",
+      "lastName": "Van der beeck",
       "email": "daniel.vanderbeeck@gmail.com"
     },
     {
       "title": "Emma Cartuyvels",
+      "firstName": "Emma",
+      "lastName": "Cartuyvels",
       "email": "emma.cartuyvels@inbo.be",
       "role": "principalInvestigator",
       "organization": "Research Institute for Nature and Forest (INBO)"
     },
     {
       "title": "Peter Desmet",
+      "firstName": "Peter",
+      "lastName": "Desmet",
       "email": "peter.desmet@inbo.be",
       "path": "https://orcid.org/0000-0002-8442-8025",
       "role": "contact",

--- a/tests/testthat/_snaps/write_camtrapdp/datapackage.json
+++ b/tests/testthat/_snaps/write_camtrapdp/datapackage.json
@@ -1,0 +1,241 @@
+{
+  "resources": [
+    {
+      "name": "deployments",
+      "path": "deployments.csv",
+      "profile": "tabular-data-resource",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "utf-8",
+      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/deployments-table-schema.json"
+    },
+    {
+      "name": "media",
+      "path": "media.csv",
+      "profile": "tabular-data-resource",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "utf-8",
+      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/media-table-schema.json"
+    },
+    {
+      "name": "observations",
+      "path": "observations.csv",
+      "profile": "tabular-data-resource",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "utf-8",
+      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/observations-table-schema.json"
+    },
+    {
+      "name": "individuals",
+      "description": "Custom table/resource not part of the Camtrap DP model. Included to showcase that extending with more resources is possible.",
+      "data": [
+        {
+          "id": 1,
+          "individualName": "Reinaert",
+          "scientificName": "Vulpes vulpes"
+        }
+      ]
+    }
+  ],
+  "profile": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/camtrap-dp-profile.json",
+  "name": "camtrap-dp-example-dataset",
+  "id": "7cca70f5-ef8c-4f86-85fb-8f070937d7ab",
+  "created": "2023-02-06T11:23:03Z",
+  "title": "Sample from: MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany",
+  "contributors": [
+    {
+      "title": "Axel Neukermans",
+      "email": "axel.neukermans@inbo.be",
+      "path": "https://orcid.org/0000-0003-0272-9180",
+      "role": "contributor",
+      "organization": "Research Institute for Nature and Forest (INBO)"
+    },
+    {
+      "title": "Danny Van der beeck",
+      "email": "daniel.vanderbeeck@gmail.com"
+    },
+    {
+      "title": "Emma Cartuyvels",
+      "email": "emma.cartuyvels@inbo.be",
+      "role": "principalInvestigator",
+      "organization": "Research Institute for Nature and Forest (INBO)"
+    },
+    {
+      "title": "Peter Desmet",
+      "email": "peter.desmet@inbo.be",
+      "path": "https://orcid.org/0000-0002-8442-8025",
+      "role": "contact",
+      "organization": "Research Institute for Nature and Forest (INBO)"
+    },
+    {
+      "title": "Research Institute for Nature and Forest (INBO)",
+      "path": "https://inbo.be",
+      "role": "rightsHolder"
+    },
+    {
+      "title": "Research Institute for Nature and Forest (INBO)",
+      "path": "https://inbo.be",
+      "role": "publisher"
+    }
+  ],
+  "description": "MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany is an occurrence dataset published by the Research Institute of Nature and Forest (INBO). It is part of the LIFE project MICA, in which innovative techniques are tested for a more efficient control of muskrat and coypu populations, both invasive species. This dataset is a sample of the original dataset and serves as an example of a Camera Trap Data Package (Camtrap DP).",
+  "version": "1.0.2",
+  "keywords": ["camera traps", "public awareness campaign", "flood protection", "flood control", "damage prevention", "animal damage", "pest control", "invasive alien species", "muskrat", "coypu"],
+  "image": "",
+  "homepage": "https://camtrap-dp.tdwg.org/example/",
+  "sources": [
+    {
+      "title": "Agouti",
+      "path": "https://www.agouti.eu",
+      "email": "agouti@wur.nl",
+      "version": "v3.21"
+    }
+  ],
+  "licenses": [
+    {
+      "name": "CC0-1.0",
+      "scope": "data"
+    },
+    {
+      "path": "http://creativecommons.org/licenses/by/4.0/",
+      "scope": "media"
+    }
+  ],
+  "bibliographicCitation": "Desmet P, Neukermans A, Van der beeck D, Cartuyvels E (2022). Sample from: MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany. Version 1.0.2. Research Institute for Nature and Forest (INBO). Dataset. https://camtrap-dp.tdwg.org/example/",
+  "project": {
+    "id": "86cabc14-d475-4439-98a7-e7b590bed60e",
+    "title": "Management of Invasive Coypu and muskrAt in Europe",
+    "acronym": "MICA",
+    "description": "Invasive alien species such as the coypu and muskrat pose a major threat to biodiversity and cost millions of euros annually. By feeding on rushes and reeds, these animals cause serious damage to the environment in which they live and endangered species suffer from habitat loss. The disappearance of reeds and digging in dikes represents a safety risk for humans in the lowland areas. With the LIFE project MICA (<https://lifemica.eu>), the partners from the participating countries want to develop a transnational plan for the management of coypu and muskrat populations in Europe and aim to reduce their population. The objective of an effective population control of coypu and muskrat is to protect lowlands from flooding, to prevent crop damage and loss of biodiversity. The objective of the project is to serve as a pilot and demonstration project in which ‘best practices’ are tested and new techniques are developed for a more efficient control of muskrat and coypu populations. By involving organisations from Belgium, Germany and the Netherlands, the project also promotes international cooperation and knowledge exchange in the field of muskrat and coypu management.",
+    "samplingDesign": "targeted",
+    "path": "https://lifemica.eu",
+    "captureMethod": ["activityDetection", "timeLapse"],
+    "individualAnimals": false,
+    "observationLevel": ["media", "event"]
+  },
+  "coordinatePrecision": 0.001,
+  "spatial": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [4.013, 50.699],
+        [5.659, 50.699],
+        [5.659, 51.496],
+        [4.013, 51.496],
+        [4.013, 50.699]
+      ]
+    ]
+  },
+  "temporal": {
+    "start": "2020-05-30",
+    "end": "2021-04-18"
+  },
+  "taxonomic": [
+    {
+      "scientificName": "Anas platyrhynchos",
+      "taxonID": "https://www.checklistbank.org/dataset/COL2023/taxon/DGP6",
+      "taxonRank": "species",
+      "vernacularNames": {
+        "nld": "wilde eend"
+      }
+    },
+    {
+      "scientificName": "Anas strepera",
+      "taxonID": "https://www.checklistbank.org/dataset/COL2023/taxon/DGPL",
+      "taxonRank": "species",
+      "vernacularNames": {
+        "eng": "gadwall",
+        "nld": "krakeend"
+      }
+    },
+    {
+      "scientificName": "Ardea",
+      "taxonID": "https://www.checklistbank.org/dataset/COL2023/taxon/32FH",
+      "taxonRank": "genus",
+      "vernacularNames": {
+        "eng": "great herons",
+        "nld": "reigers"
+      }
+    },
+    {
+      "scientificName": "Ardea cinerea",
+      "taxonID": "https://www.checklistbank.org/dataset/COL2023/taxon/GCHS",
+      "taxonRank": "species",
+      "vernacularNames": {
+        "eng": "grey heron",
+        "nld": "blauwe reiger"
+      }
+    },
+    {
+      "scientificName": "Aves",
+      "taxonID": "https://www.checklistbank.org/dataset/COL2023/taxon/V2",
+      "taxonRank": "class",
+      "vernacularNames": {
+        "eng": "bird sp.",
+        "nld": "vogel"
+      }
+    },
+    {
+      "scientificName": "Homo sapiens",
+      "taxonID": "https://www.checklistbank.org/dataset/COL2023/taxon/6MB3T",
+      "taxonRank": "species",
+      "vernacularNames": {
+        "eng": "human",
+        "nld": "mens"
+      }
+    },
+    {
+      "scientificName": "Martes foina",
+      "taxonID": "https://www.checklistbank.org/dataset/COL2023/taxon/3Y9VW",
+      "taxonRank": "species",
+      "vernacularNames": {
+        "eng": "beech marten",
+        "nld": "steenmarter"
+      }
+    },
+    {
+      "scientificName": "Mustela putorius",
+      "taxonID": "https://www.checklistbank.org/dataset/COL2023/taxon/44QYC",
+      "taxonRank": "species",
+      "vernacularNames": {
+        "eng": "European polecat",
+        "nld": "bunzing"
+      }
+    },
+    {
+      "scientificName": "Rattus norvegicus",
+      "taxonID": "https://www.checklistbank.org/dataset/COL2023/taxon/4RM67",
+      "taxonRank": "species",
+      "vernacularNames": {
+        "eng": "brown rat",
+        "nld": "bruine rat"
+      }
+    },
+    {
+      "scientificName": "Vulpes vulpes",
+      "taxonID": "https://www.checklistbank.org/dataset/COL2023/taxon/5BSG3",
+      "taxonRank": "species",
+      "vernacularNames": {
+        "eng": "red fox",
+        "nld": "vos"
+      }
+    }
+  ],
+  "relatedIdentifiers": [
+    {
+      "relationType": "IsDerivedFrom",
+      "relatedIdentifier": "https://doi.org/10.15468/5tb6ze",
+      "resourceTypeGeneral": "Dataset",
+      "relatedIdentifierType": "DOI"
+    },
+    {
+      "relationType": "IsSupplementTo",
+      "relatedIdentifier": "https://inbo.github.io/camtrapdp/",
+      "resourceTypeGeneral": "Software",
+      "relatedIdentifierType": "URL"
+    }
+  ],
+  "references": []
+}

--- a/tests/testthat/test-write_camtrapdp.R
+++ b/tests/testthat/test-write_camtrapdp.R
@@ -92,8 +92,8 @@ test_that("write_camtrapdp() can write compressed files", {
   )
 })
 
-test_that("write_camtrapdp() returns the expected json when elements in
-          x$taxonomic are missing", {
+test_that("write_camtrapdp() removes NA elements in `x$taxonomic` and
+          `x$contributors`", {
   skip_if_offline()
   x <- example_dataset()
   temp_dir <- tempdir()
@@ -108,7 +108,6 @@ test_that("write_camtrapdp() returns the expected json when elements in
         vernacularNames.nld = "wilde eend"
       )
     )
-
   contributors(x_updated) <- contributors(x)
   write_camtrapdp(x_updated, temp_dir)
 

--- a/tests/testthat/test-write_camtrapdp.R
+++ b/tests/testthat/test-write_camtrapdp.R
@@ -108,6 +108,8 @@ test_that("write_camtrapdp() returns the expected json when elements in
         vernacularNames.nld = "wilde eend"
       )
     )
+
+  contributors(x_updated) <- contributors(x)
   write_camtrapdp(x_updated, temp_dir)
 
   expect_snapshot_file(file.path(temp_dir, "datapackage.json"))

--- a/tests/testthat/test-write_camtrapdp.R
+++ b/tests/testthat/test-write_camtrapdp.R
@@ -91,3 +91,24 @@ test_that("write_camtrapdp() can write compressed files", {
       "observations.csv.gz")
   )
 })
+
+test_that("write_camtrapdp() returns the expected json when elements in
+          x$taxonomic are missing", {
+  skip_if_offline()
+  x <- example_dataset()
+  temp_dir <- tempdir()
+  on.exit(unlink(temp_dir, recursive = TRUE))
+  x_updated <- x %>%
+    update_taxon(
+      from = "Anas platyrhynchos",
+      to = list(
+        scientificName = "Anas platyrhynchos",
+        taxonID = "https://www.checklistbank.org/dataset/COL2023/taxon/DGP6",
+        taxonRank = "species",
+        vernacularNames.nld = "wilde eend"
+      )
+    )
+  write_camtrapdp(x_updated, temp_dir)
+
+  expect_snapshot_file(file.path(temp_dir, "datapackage.json"))
+})

--- a/tests/testthat/test-write_camtrapdp.R
+++ b/tests/testthat/test-write_camtrapdp.R
@@ -92,12 +92,14 @@ test_that("write_camtrapdp() can write compressed files", {
   )
 })
 
-test_that("write_camtrapdp() removes NA elements in `x$taxonomic` and
-          `x$contributors`", {
+test_that("write_camtrapdp() returns the expected datapackage.json for the
+           example dataset", {
   skip_if_offline()
   x <- example_dataset()
   temp_dir <- tempdir()
   on.exit(unlink(temp_dir, recursive = TRUE))
+
+  # Adapt x$taxonomic and x$contributors to test for bug #185
   x_updated <- x %>%
     update_taxon(
       from = "Anas platyrhynchos",

--- a/tests/testthat/test-write_camtrapdp.R
+++ b/tests/testthat/test-write_camtrapdp.R
@@ -99,19 +99,19 @@ test_that("write_camtrapdp() returns the expected datapackage.json for the
   temp_dir <- tempdir()
   on.exit(unlink(temp_dir, recursive = TRUE))
 
-  # Adapt x$taxonomic and x$contributors to test for bug #185
-  x_updated <- x %>%
+  # Adapt x$taxonomic and x$contributors to test for https://github.com/inbo/camtrapdp/issues/185
+  x <- x %>%
     update_taxon(
       from = "Anas platyrhynchos",
       to = list(
         scientificName = "Anas platyrhynchos",
         taxonID = "https://www.checklistbank.org/dataset/COL2023/taxon/DGP6",
         taxonRank = "species",
-        vernacularNames.nld = "wilde eend"
+        vernacularNames.nld = "wilde eend" # Assigns NA for vernacularNames.eng
       )
     )
-  contributors(x_updated) <- contributors(x)
-  write_camtrapdp(x_updated, temp_dir)
+  contributors(x) <- contributors(x) # Assigns NA for e.g. firstName of INBO
+  write_camtrapdp(x, temp_dir)
 
   expect_snapshot_file(file.path(temp_dir, "datapackage.json"))
 })


### PR DESCRIPTION
`write_camtrapdp()` now recursively removes NA values nested in `x$taxonomic` and `x$contributors`, fix #185.