### PR TITLE
Use <para> not <p> per line in description

### DIFF
--- a/R/write_eml.R
+++ b/R/write_eml.R
@@ -77,10 +77,9 @@ write_eml <- function(x, directory, derived_paragraph = TRUE) {
 
   # Set abstract, with optional extra paragraph
   para <-
-    # Split description per line, remove empty lines, wrap each line in <p></p>
+    # Split description per line/<p>, remove empty lines, assign as <para>s
     unlist(strsplit(x$description, "<p>|</p>|\n")) %>%
-    purrr::discard(~ .x == "") %>%
-    purrr::map_chr(~ paste0("<p>", ., "</p>"))
+    purrr::discard(~ .x == "")
   if (derived_paragraph) {
     last_para <- paste0(
       "Data have been standardized to Darwin Core using the ",

--- a/tests/testthat/_snaps/write_eml/eml.xml
+++ b/tests/testthat/_snaps/write_eml/eml.xml
@@ -52,9 +52,7 @@
     </metadataProvider>
     <pubDate>2023-02-06</pubDate>
     <abstract>
-      <para>
-        <p>MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany is an occurrence dataset published by the Research Institute of Nature and Forest (INBO). It is part of the LIFE project MICA, in which innovative techniques are tested for a more efficient control of muskrat and coypu populations, both invasive species. This dataset is a sample of the original dataset and serves as an example of a Camera Trap Data Package (Camtrap DP).</p>
-      </para>
+      <para>MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany is an occurrence dataset published by the Research Institute of Nature and Forest (INBO). It is part of the LIFE project MICA, in which innovative techniques are tested for a more efficient control of muskrat and coypu populations, both invasive species. This dataset is a sample of the original dataset and serves as an example of a Camera Trap Data Package (Camtrap DP).</para>
       <para>Data have been standardized to Darwin Core using the <ulink url="https://inbo.github.io/camtrapdp/"><citetitle>camtrapdp</citetitle></ulink> R package and only include observations (and associated media) of animals. Excluded are records that document blank or unclassified media vehicles and observations of humans.</para>
     </abstract>
     <keywordSet>


### PR DESCRIPTION
Currently `x$description` is being split per line or `<p>` (with empty lines removed) and added to EML as one HTML `<p>` per line:

```ini
# Input
First sentence.

<p>Second sentence.</p>

# EML output
<para>
  <p>First sentence.</p>
  <p>Second sentence.</p>
</para>
<para>Derived paragraph ...</para>
```

Since the EML `<para>` technically doesn't support HTML, I think the output should be one `<para>` per line:

```ini
# Input
First sentence.

<p>Second sentence.</p>

# EML output
<para>First sentence.</para>
<para>Second sentence.</para>
<para>Derived paragraph ...</para>
```

This is in line with how movepub's `html_to_docbook()` treats incoming `<p></p>`.

Note: no other parsing is done of the content of `x$description`, which may contain Markdown (and thus HTML). I don't consider that a need at the moment.

---

@sannegovaert since the generated EML is directly used by GBIF, could you a test similar to #188 on how GBIF.org displays the example dataset with `<para>` rather than `<p>`?