### PR TITLE
Add `year(col_name)` to filter functions examples

### DIFF
--- a/R/filter_deployments.R
+++ b/R/filter_deployments.R
@@ -35,6 +35,10 @@
 #' # Filtering on dates is easiest with lubridate
 #' library(lubridate, warn.conflicts = FALSE)
 #' x %>%
+#'   filter_deployments(lubridate::year(deploymentStart) == 2020) %>%
+#'   deployments()
+#'
+#' x %>%
 #'   filter_deployments(
 #'     deploymentStart >= lubridate::as_date("2020-06-19"),
 #'     deploymentEnd <= lubridate::as_date("2020-08-30")

--- a/R/filter_media.R
+++ b/R/filter_media.R
@@ -34,6 +34,10 @@
 #' # Filtering on datetimes is easiest with lubridate
 #' library(lubridate, warn.conflicts = FALSE)
 #' x %>%
+#'   filter_media(lubridate::year(timestamp) == 2020) %>%
+#'   media()
+#'
+#' x %>%
 #'   filter_media(
 #'     timestamp >= lubridate::as_datetime("2020-08-02 05:01:00"),
 #'     timestamp <= lubridate::as_datetime("2020-08-02 05:02:00")

--- a/R/filter_observations.R
+++ b/R/filter_observations.R
@@ -48,6 +48,10 @@
 #' # Filtering on datetimes is easiest with lubridate
 #' library(lubridate, warn.conflicts = FALSE)
 #' x %>%
+#'   filter_observations(lubridate::year(eventStart) == 2020) %>%
+#'   observations()
+#'
+#' x %>%
 #'   filter_observations(
 #'     eventStart >= lubridate::as_datetime("2020-06-19 22:00:00"),
 #'     eventEnd <= lubridate::as_datetime("2020-06-19 22:10:00")

--- a/man/filter_deployments.Rd
+++ b/man/filter_deployments.Rd
@@ -45,6 +45,10 @@ x \%>\%
 # Filtering on dates is easiest with lubridate
 library(lubridate, warn.conflicts = FALSE)
 x \%>\%
+  filter_deployments(lubridate::year(deploymentStart) == 2020) \%>\%
+  deployments()
+
+x \%>\%
   filter_deployments(
     deploymentStart >= lubridate::as_date("2020-06-19"),
     deploymentEnd <= lubridate::as_date("2020-08-30")

--- a/man/filter_media.Rd
+++ b/man/filter_media.Rd
@@ -44,6 +44,10 @@ x \%>\%
 # Filtering on datetimes is easiest with lubridate
 library(lubridate, warn.conflicts = FALSE)
 x \%>\%
+  filter_media(lubridate::year(timestamp) == 2020) \%>\%
+  media()
+
+x \%>\%
   filter_media(
     timestamp >= lubridate::as_datetime("2020-08-02 05:01:00"),
     timestamp <= lubridate::as_datetime("2020-08-02 05:02:00")

--- a/man/filter_observations.Rd
+++ b/man/filter_observations.Rd
@@ -58,6 +58,10 @@ x \%>\%
 # Filtering on datetimes is easiest with lubridate
 library(lubridate, warn.conflicts = FALSE)
 x \%>\%
+  filter_observations(lubridate::year(eventStart) == 2020) \%>\%
+  observations()
+
+x \%>\%
   filter_observations(
     eventStart >= lubridate::as_datetime("2020-06-19 22:00:00"),
     eventEnd <= lubridate::as_datetime("2020-06-19 22:10:00")


### PR DESCRIPTION
Inspired by a question by @jimcasaer.

You can filter a Camtrap DP object on year, month, etc. by wrapping the column name in `year()`, `month()` etc. Pretty neat, so useful to add as an example to all functions.

```R
# Filtering on dates is easiest with lubridate
library(lubridate, warn.conflicts = FALSE)
x %>%
  filter_deployments(lubridate::year(deploymentStart) == 2020) %>%
  deployments()
#> # A tibble: 3 × 24
#>   deploymentID locationID locationName  latitude longitude coordinateUncertainty
#>   <chr>        <chr>      <chr>            <dbl>     <dbl>                 <dbl>
#> 1 00a2c20d     e254a13c   B_HS_val 2_p…     51.5      4.77                   187
#> 2 29b7d356     2df5259b   B_DL_val 5_b…     51.2      5.66                   187
#> 3 577b543a     ff1535c0   B_DL_val 3_d…     51.2      5.66                   187
#> # ℹ 18 more variables: deploymentStart <dttm>, deploymentEnd <dttm>,
#> #   setupBy <chr>, cameraID <chr>, cameraModel <chr>, cameraDelay <dbl>,
#> #   cameraHeight <dbl>, cameraDepth <dbl>, cameraTilt <dbl>,
#> #   cameraHeading <dbl>, detectionDistance <dbl>, timestampIssues <lgl>,
#> #   baitUse <lgl>, featureType <fct>, habitat <chr>, deploymentGroups <chr>,
#> #   deploymentTags <chr>, deploymentComments <chr>

```